### PR TITLE
feat: add session control commands for active ACP sessions

### DIFF
--- a/src/telegram_acp_bot/acp_app/echo_service.py
+++ b/src/telegram_acp_bot/acp_app/echo_service.py
@@ -34,3 +34,15 @@ class EchoAgentService:
     def get_workspace(self, *, chat_id: int) -> Path | None:
         session = self._registry.get(chat_id)
         return None if session is None else session.workspace
+
+    async def cancel(self, *, chat_id: int) -> bool:
+        return self._registry.get(chat_id) is not None
+
+    async def stop(self, *, chat_id: int) -> bool:
+        if self._registry.get(chat_id) is None:
+            return False
+        self._registry.clear(chat_id)
+        return True
+
+    async def clear(self, *, chat_id: int) -> bool:
+        return await self.stop(chat_id=chat_id)


### PR DESCRIPTION
## Summary
Implements explicit Telegram session control commands:
- `/cancel`
- `/stop`
- `/clear`

## Changes
- Added control methods to agent service protocol and implementations
- Added command handlers and help text updates in Telegram bridge
- Added ACP service lifecycle handling for cancel/stop/clear
- Expanded tests for all control paths and access checks

## Validation
- `uv run ruff check src tests`
- `uv run pytest`
