### PR TITLE
feat: add session and next-prompt permission policies

### DIFF
--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -36,12 +36,6 @@ def get_parser() -> argparse.ArgumentParser:
         help="ACP agent command line, e.g. 'codex-acp' or 'uv run examples/echo_agent.py'.",
     )
     parser.add_argument(
-        "--auto-approve-permissions",
-        action="store_true",
-        default=os.getenv("ACP_AUTO_APPROVE_PERMISSIONS", "").lower() in {"1", "true", "yes"},
-        help="Automatically approve tool permission prompts from the ACP agent.",
-    )
-    parser.add_argument(
         "--allowed-user-id",
         action="append",
         default=[],
@@ -80,7 +74,6 @@ def main(args: list[str] | None = None) -> int:
         SessionRegistry(),
         program=command_parts[0],
         args=command_parts[1:],
-        auto_approve_permissions=opts.auto_approve_permissions,
     )
     bridge = TelegramBridge(config=config, agent_service=service)
     return run_polling(config, bridge)

--- a/src/telegram_acp_bot/acp_app/echo_service.py
+++ b/src/telegram_acp_bot/acp_app/echo_service.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 
+from telegram_acp_bot.acp_app.models import AgentReply, PermissionMode, PermissionPolicy
 from telegram_acp_bot.core.session_registry import SessionRegistry
-
-
-@dataclass(slots=True, frozen=True)
-class AgentReply:
-    """Normalized response from the agent layer."""
-
-    text: str
 
 
 class EchoAgentService:
@@ -18,9 +11,13 @@ class EchoAgentService:
 
     def __init__(self, registry: SessionRegistry) -> None:
         self._registry = registry
+        self._session_permission_mode: dict[int, PermissionMode] = {}
+        self._next_prompt_auto_approve: dict[int, bool] = {}
 
     async def new_session(self, *, chat_id: int, workspace: Path) -> str:
         session = self._registry.create_or_replace(chat_id=chat_id, workspace=workspace)
+        self._session_permission_mode[chat_id] = "deny"
+        self._next_prompt_auto_approve[chat_id] = False
         return session.session_id
 
     async def prompt(self, *, chat_id: int, text: str) -> AgentReply | None:
@@ -42,7 +39,29 @@ class EchoAgentService:
         if self._registry.get(chat_id) is None:
             return False
         self._registry.clear(chat_id)
+        self._session_permission_mode.pop(chat_id, None)
+        self._next_prompt_auto_approve.pop(chat_id, None)
         return True
 
     async def clear(self, *, chat_id: int) -> bool:
         return await self.stop(chat_id=chat_id)
+
+    def get_permission_policy(self, *, chat_id: int) -> PermissionPolicy | None:
+        if self._registry.get(chat_id) is None:
+            return None
+        return PermissionPolicy(
+            session_mode=self._session_permission_mode.get(chat_id, "deny"),
+            next_prompt_auto_approve=self._next_prompt_auto_approve.get(chat_id, False),
+        )
+
+    async def set_session_permission_mode(self, *, chat_id: int, mode: PermissionMode) -> bool:
+        if self._registry.get(chat_id) is None:
+            return False
+        self._session_permission_mode[chat_id] = mode
+        return True
+
+    async def set_next_prompt_auto_approve(self, *, chat_id: int, enabled: bool) -> bool:
+        if self._registry.get(chat_id) is None:
+            return False
+        self._next_prompt_auto_approve[chat_id] = enabled
+        return True

--- a/src/telegram_acp_bot/acp_app/models.py
+++ b/src/telegram_acp_bot/acp_app/models.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PermissionMode = Literal["deny", "approve"]
+
+
+@dataclass(slots=True, frozen=True)
+class AgentReply:
+    """Normalized response from the agent layer."""
+
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class PermissionPolicy:
+    """Permission policy state for one chat session."""
+
+    session_mode: PermissionMode
+    next_prompt_auto_approve: bool

--- a/tests/test_acp_echo_service.py
+++ b/tests/test_acp_echo_service.py
@@ -30,3 +30,10 @@ def test_get_workspace() -> None:
     assert service.get_workspace(chat_id=1) is None
     asyncio.run(service.new_session(chat_id=1, workspace=Path("/work")))
     assert service.get_workspace(chat_id=1) == Path("/work")
+
+
+def test_permission_policy_updates_without_session() -> None:
+    service = EchoAgentService(SessionRegistry())
+    assert asyncio.run(service.set_session_permission_mode(chat_id=1, mode="approve")) is False
+    assert asyncio.run(service.set_next_prompt_auto_approve(chat_id=1, enabled=True)) is False
+    assert service.get_permission_policy(chat_id=1) is None


### PR DESCRIPTION
Stacked PR over #17.

Implements permission policy controls:
- /perm
- /perm session approve|deny
- /perm next on|off

Includes service-level enforcement and full tests.
