### PR TITLE
Drop redundant return annotations in tests

### DIFF
--- a/tests/test_acp_echo_service.py
+++ b/tests/test_acp_echo_service.py
@@ -7,14 +7,14 @@ from telegram_acp_bot.acp_app.echo_service import EchoAgentService
 from telegram_acp_bot.core.session_registry import SessionRegistry
 
 
-def test_prompt_without_session_returns_none() -> None:
+def test_prompt_without_session_returns_none():
     service = EchoAgentService(SessionRegistry())
 
     reply = asyncio.run(service.prompt(chat_id=1, text="hello"))
     assert reply is None
 
 
-def test_new_session_and_prompt(tmp_path: Path) -> None:
+def test_new_session_and_prompt(tmp_path: Path):
     service = EchoAgentService(SessionRegistry())
     workspace = tmp_path / "echo-service-test-workspace"
 
@@ -27,7 +27,7 @@ def test_new_session_and_prompt(tmp_path: Path) -> None:
     assert session_id.split("-", maxsplit=1)[0] in reply.text
 
 
-def test_get_workspace(tmp_path: Path) -> None:
+def test_get_workspace(tmp_path: Path):
     service = EchoAgentService(SessionRegistry())
     workspace = tmp_path / "echo-service-test-workspace-2"
 
@@ -36,14 +36,14 @@ def test_get_workspace(tmp_path: Path) -> None:
     assert service.get_workspace(chat_id=1) == workspace
 
 
-def test_permission_policy_updates_without_session() -> None:
+def test_permission_policy_updates_without_session():
     service = EchoAgentService(SessionRegistry())
     assert asyncio.run(service.set_session_permission_mode(chat_id=1, mode="approve")) is False
     assert asyncio.run(service.set_next_prompt_auto_approve(chat_id=1, enabled=True)) is False
     assert service.get_permission_policy(chat_id=1) is None
 
 
-def test_permission_policy_defaults_and_updates(tmp_path: Path) -> None:
+def test_permission_policy_defaults_and_updates(tmp_path: Path):
     service = EchoAgentService(SessionRegistry())
     workspace = tmp_path / "echo-policy"
     asyncio.run(service.new_session(chat_id=1, workspace=workspace))
@@ -61,7 +61,7 @@ def test_permission_policy_defaults_and_updates(tmp_path: Path) -> None:
     assert updated.next_prompt_auto_approve is True
 
 
-def test_permission_handler_and_response_are_noop() -> None:
+def test_permission_handler_and_response_are_noop():
     service = EchoAgentService(SessionRegistry())
 
     async def handler(request):
@@ -71,7 +71,7 @@ def test_permission_handler_and_response_are_noop() -> None:
     assert asyncio.run(service.respond_permission_request(chat_id=1, request_id="x", action="deny")) is False
 
 
-def test_new_session_rejects_file_workspace(tmp_path: Path) -> None:
+def test_new_session_rejects_file_workspace(tmp_path: Path):
     service = EchoAgentService(SessionRegistry())
     invalid = tmp_path / "file.txt"
     invalid.write_text("x")

--- a/tests/test_acp_service.py
+++ b/tests/test_acp_service.py
@@ -115,7 +115,7 @@ class FileResourceConnection(FakeConnection):
         return SimpleNamespace(stop_reason="end_turn")
 
 
-def test_acp_client_capture_text_and_media_markers() -> None:
+def test_acp_client_capture_text_and_media_markers():
     client = make_client()
     session_id = "s1"
     client.start_capture(session_id)
@@ -129,7 +129,7 @@ def test_acp_client_capture_text_and_media_markers() -> None:
     assert reply.files == ()
 
 
-def test_acp_client_ignores_non_message_updates() -> None:
+def test_acp_client_ignores_non_message_updates():
     client = make_client()
     session_id = "s-ignore"
     client.start_capture(session_id)
@@ -137,7 +137,7 @@ def test_acp_client_ignores_non_message_updates() -> None:
     assert asyncio.run(client.finish_capture(session_id)).text == ""
 
 
-def test_acp_client_capture_non_text_content_markers() -> None:
+def test_acp_client_capture_non_text_content_markers():
     client = make_client()
     session_id = "s2"
     client.start_capture(session_id)
@@ -180,7 +180,7 @@ def test_acp_client_capture_non_text_content_markers() -> None:
     assert len(reply.files) == EXPECTED_CAPTURED_FILES + 1
 
 
-def test_acp_client_permission_decision_auto_approve() -> None:
+def test_acp_client_permission_decision_auto_approve():
     client = make_client()
     option = PermissionOption(kind="allow_once", name="Allow once", option_id="opt-1")
     tool_call = ToolCall(title="execute", tool_call_id="tc-1")
@@ -190,7 +190,7 @@ def test_acp_client_permission_decision_auto_approve() -> None:
     assert asyncio.run(client.finish_capture("s")).text == ""
 
 
-def test_acp_client_permission_decision_cancelled() -> None:
+def test_acp_client_permission_decision_cancelled():
     async def deny_all(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
         del tool_call
         del options
@@ -205,7 +205,7 @@ def test_acp_client_permission_decision_cancelled() -> None:
     assert asyncio.run(client.finish_capture("s")).text == ""
 
 
-def test_acp_client_capture_tool_events() -> None:
+def test_acp_client_capture_tool_events():
     async def allow_first(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
         del options, tool_call
         return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
@@ -230,7 +230,7 @@ def test_acp_client_capture_tool_events() -> None:
     assert "tool completed tool-1 read file" in events[1]
 
 
-def test_acp_client_emits_live_activity_blocks() -> None:
+def test_acp_client_emits_live_activity_blocks():
     events: list[AgentActivityBlock] = []
 
     async def allow_first(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
@@ -271,7 +271,7 @@ def test_acp_client_emits_live_activity_blocks() -> None:
     assert events[1] == AgentActivityBlock(kind="execute", title="Run command", status="in_progress", text="")
 
 
-def test_acp_client_flushes_non_tool_text_as_thinking_before_next_tool() -> None:
+def test_acp_client_flushes_non_tool_text_as_thinking_before_next_tool():
     events: list[AgentActivityBlock] = []
 
     async def allow_first(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
@@ -323,7 +323,7 @@ def test_acp_client_flushes_non_tool_text_as_thinking_before_next_tool() -> None
     assert reply.text == "final output"
 
 
-def test_acp_client_drops_empty_non_tool_text_when_flushing() -> None:
+def test_acp_client_drops_empty_non_tool_text_when_flushing():
     events: list[AgentActivityBlock] = []
 
     async def allow_first(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
@@ -348,7 +348,7 @@ def test_acp_client_drops_empty_non_tool_text_when_flushing() -> None:
     assert events == [AgentActivityBlock(kind="execute", title="Run cmd", status="in_progress", text="")]
 
 
-def test_acp_client_groups_tool_output_into_activity_blocks() -> None:
+def test_acp_client_groups_tool_output_into_activity_blocks():
     client = make_client()
     session_id = "s-blocks"
     client.start_capture(session_id)
@@ -392,7 +392,7 @@ def test_acp_client_groups_tool_output_into_activity_blocks() -> None:
     )
 
 
-def test_acp_client_moves_trailing_non_think_block_text_to_final_reply() -> None:
+def test_acp_client_moves_trailing_non_think_block_text_to_final_reply():
     client = make_client()
     session_id = "s-trailing"
     client.start_capture(session_id)
@@ -419,7 +419,7 @@ def test_acp_client_moves_trailing_non_think_block_text_to_final_reply() -> None
     assert reply.text == "This should be final."
 
 
-def test_acp_client_ignores_terminal_progress_for_different_tool() -> None:
+def test_acp_client_ignores_terminal_progress_for_different_tool():
     client = make_client()
     session_id = "s-mismatch"
     client.start_capture(session_id)
@@ -465,14 +465,14 @@ def test_acp_client_ignores_terminal_progress_for_different_tool() -> None:
         ("kill_terminal", {"session_id": "s", "terminal_id": "t"}),
     ],
 )
-def test_acp_client_unsupported_methods_raise(method_name: str, args: dict[str, str]) -> None:
+def test_acp_client_unsupported_methods_raise(method_name: str, args: dict[str, str]):
     client = make_client()
     method = getattr(client, method_name)
     with pytest.raises(RequestError):
         asyncio.run(method(**args))
 
 
-def test_acp_client_unsupported_ext_methods_raise() -> None:
+def test_acp_client_unsupported_ext_methods_raise():
     client = make_client()
     with pytest.raises(RequestError):
         asyncio.run(client.ext_method("x", {}))
@@ -480,7 +480,7 @@ def test_acp_client_unsupported_ext_methods_raise() -> None:
         asyncio.run(client.ext_notification("x", {}))
 
 
-def test_new_session_creates_missing_workspace(tmp_path: Path) -> None:
+def test_new_session_creates_missing_workspace(tmp_path: Path):
     missing = tmp_path / "missing"
     process = FakeProcess()
     connection = FakeConnection(session_id="created")
@@ -506,7 +506,7 @@ def test_new_session_creates_missing_workspace(tmp_path: Path) -> None:
     assert missing.is_dir()
 
 
-def test_new_session_rejects_file_workspace(tmp_path: Path) -> None:
+def test_new_session_rejects_file_workspace(tmp_path: Path):
     service = AcpAgentService(SessionRegistry(), program="agent", args=[])
     invalid = tmp_path / "not-a-dir"
     invalid.write_text("x")
@@ -515,7 +515,7 @@ def test_new_session_rejects_file_workspace(tmp_path: Path) -> None:
         asyncio.run(service.new_session(chat_id=1, workspace=invalid))
 
 
-def test_new_session_rejects_process_without_stdio(tmp_path: Path) -> None:
+def test_new_session_rejects_process_without_stdio(tmp_path: Path):
     workspace = tmp_path
 
     async def fake_spawn(program: str, *args: str, **kwargs):
@@ -528,12 +528,12 @@ def test_new_session_rejects_process_without_stdio(tmp_path: Path) -> None:
         asyncio.run(service.new_session(chat_id=1, workspace=workspace))
 
 
-def test_acp_service_rejects_non_positive_stdio_limit() -> None:
+def test_acp_service_rejects_non_positive_stdio_limit():
     with pytest.raises(ValueError):
         AcpAgentService(SessionRegistry(), program="agent", args=[], stdio_limit=0)
 
 
-def test_new_session_passes_stdio_limit_to_spawner(tmp_path: Path) -> None:
+def test_new_session_passes_stdio_limit_to_spawner(tmp_path: Path):
     process = FakeProcess()
     limits: list[int] = []
 
@@ -560,7 +560,7 @@ def test_new_session_passes_stdio_limit_to_spawner(tmp_path: Path) -> None:
     assert limits == [2_000_000]
 
 
-def test_new_session_and_prompt(tmp_path: Path) -> None:
+def test_new_session_and_prompt(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="real-session")
 
@@ -594,13 +594,13 @@ def test_new_session_and_prompt(tmp_path: Path) -> None:
     assert connection.prompt_calls == ["real-session"]
 
 
-def test_prompt_without_active_session_returns_none() -> None:
+def test_prompt_without_active_session_returns_none():
     service = AcpAgentService(SessionRegistry(), program="agent", args=[])
     reply = asyncio.run(service.prompt(chat_id=99, text="hi"))
     assert reply is None
 
 
-def test_prompt_resolves_file_uri_resource_as_image(tmp_path: Path) -> None:
+def test_prompt_resolves_file_uri_resource_as_image(tmp_path: Path):
     workspace = tmp_path / "ws"
     image_path = workspace / "img sample.png"
     image_path.parent.mkdir(parents=True, exist_ok=True)
@@ -631,7 +631,7 @@ def test_prompt_resolves_file_uri_resource_as_image(tmp_path: Path) -> None:
     assert reply.files == ()
 
 
-def test_prompt_resolves_file_uri_resource_as_document(tmp_path: Path) -> None:
+def test_prompt_resolves_file_uri_resource_as_document(tmp_path: Path):
     workspace = tmp_path / "ws"
     text_file = workspace / "note.txt"
     text_file.parent.mkdir(parents=True, exist_ok=True)
@@ -664,7 +664,7 @@ def test_prompt_resolves_file_uri_resource_as_document(tmp_path: Path) -> None:
     assert reply.files[0].data_base64 == base64.b64encode(b"hello file").decode("ascii")
 
 
-def test_prompt_reports_warning_for_outside_workspace_file_uri(tmp_path: Path) -> None:
+def test_prompt_reports_warning_for_outside_workspace_file_uri(tmp_path: Path):
     workspace = tmp_path / "ws"
     workspace.mkdir(parents=True, exist_ok=True)
     outside = tmp_path / "outside.png"
@@ -696,7 +696,7 @@ def test_prompt_reports_warning_for_outside_workspace_file_uri(tmp_path: Path) -
     assert "Attachment warning: outside.png: path is outside active workspace" in reply.text
 
 
-def test_prompt_resolves_percent_encoded_file_uri(tmp_path: Path) -> None:
+def test_prompt_resolves_percent_encoded_file_uri(tmp_path: Path):
     workspace = tmp_path / "ws"
     workspace.mkdir(parents=True, exist_ok=True)
     encoded_name = "encoded file.png"
@@ -727,7 +727,7 @@ def test_prompt_resolves_percent_encoded_file_uri(tmp_path: Path) -> None:
     assert reply.images[0].mime_type == "image/png"
 
 
-def test_cancel_and_stop_lifecycle(tmp_path: Path) -> None:
+def test_cancel_and_stop_lifecycle(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="s1")
 
@@ -756,7 +756,7 @@ def test_cancel_and_stop_lifecycle(tmp_path: Path) -> None:
     assert not asyncio.run(service.cancel(chat_id=7))
 
 
-def test_permission_policy_session_and_next_prompt(tmp_path: Path) -> None:
+def test_permission_policy_session_and_next_prompt(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="perm-session")
 
@@ -807,7 +807,7 @@ def test_permission_policy_session_and_next_prompt(tmp_path: Path) -> None:
     assert service.get_permission_policy(chat_id=999) is None
 
 
-def test_decide_permission_states(tmp_path: Path) -> None:
+def test_decide_permission_states(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="perm")
 
@@ -855,7 +855,7 @@ def test_decide_permission_states(tmp_path: Path) -> None:
     assert approved_prompt.outcome.outcome == "selected"
 
 
-def test_decide_permission_ask_mode_with_handler(tmp_path: Path) -> None:
+def test_decide_permission_ask_mode_with_handler(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="ask")
     captured: list[tuple[str, tuple[str, ...]]] = []
@@ -892,7 +892,7 @@ def test_decide_permission_ask_mode_with_handler(tmp_path: Path) -> None:
     assert "deny" in captured[0][1]
 
 
-def test_respond_permission_request_always_enables_session_approve(tmp_path: Path) -> None:
+def test_respond_permission_request_always_enables_session_approve(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="always")
 
@@ -927,12 +927,12 @@ def test_respond_permission_request_always_enables_session_approve(tmp_path: Pat
     assert policy.session_mode == "approve"
 
 
-def test_respond_permission_request_rejects_unknown_request(tmp_path: Path) -> None:
+def test_respond_permission_request_rejects_unknown_request(tmp_path: Path):
     service = AcpAgentService(SessionRegistry(), program="agent", args=[], default_permission_mode="ask")
     assert not asyncio.run(service.respond_permission_request(chat_id=1, request_id="missing", action="deny"))
 
 
-def test_stop_cancels_pending_permission_requests(tmp_path: Path) -> None:
+def test_stop_cancels_pending_permission_requests(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="pending")
 
@@ -972,7 +972,7 @@ def test_stop_cancels_pending_permission_requests(tmp_path: Path) -> None:
     asyncio.run(scenario())
 
 
-def test_decide_permission_timeout_returns_cancelled(tmp_path: Path, monkeypatch) -> None:
+def test_decide_permission_timeout_returns_cancelled(tmp_path: Path, monkeypatch):
     process = FakeProcess()
     connection = FakeConnection(session_id="timeout")
 
@@ -1011,7 +1011,7 @@ def test_decide_permission_timeout_returns_cancelled(tmp_path: Path, monkeypatch
     assert response.outcome.outcome == "cancelled"
 
 
-def test_build_permission_response_fallbacks() -> None:
+def test_build_permission_response_fallbacks():
     deny = AcpAgentService._build_permission_response(options=(), action="deny")
     assert deny.outcome.outcome == "cancelled"
 
@@ -1019,7 +1019,7 @@ def test_build_permission_response_fallbacks() -> None:
     assert fallback.outcome.outcome == "cancelled"
 
 
-def test_report_permission_event_respects_output_mode(caplog: pytest.LogCaptureFixture) -> None:
+def test_report_permission_event_respects_output_mode(caplog: pytest.LogCaptureFixture):
     service = AcpAgentService(SessionRegistry(), program="agent", args=[], permission_event_output="off")
     with caplog.at_level(logging.INFO):
         service._report_permission_event("x")
@@ -1031,7 +1031,7 @@ def test_report_permission_event_respects_output_mode(caplog: pytest.LogCaptureF
     assert any("ACP permission event: y" in record.message for record in caplog.records)
 
 
-def test_forward_activity_event_routes_to_matching_chat(tmp_path: Path) -> None:
+def test_forward_activity_event_routes_to_matching_chat(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="activity-session")
     received: list[tuple[int, AgentActivityBlock]] = []
@@ -1063,7 +1063,7 @@ def test_forward_activity_event_routes_to_matching_chat(tmp_path: Path) -> None:
     assert received == [(7, block)]
 
 
-def test_new_session_replaces_previous_and_shuts_down(tmp_path: Path, monkeypatch) -> None:
+def test_new_session_replaces_previous_and_shuts_down(tmp_path: Path, monkeypatch):
     first = FakeProcess()
     second = FakeProcess()
     calls: list[FakeProcess] = []
@@ -1103,7 +1103,7 @@ def test_new_session_replaces_previous_and_shuts_down(tmp_path: Path, monkeypatc
     assert not finished.terminated
 
 
-def test_resolve_file_uri_resources_keeps_non_file_payloads(tmp_path: Path) -> None:
+def test_resolve_file_uri_resources_keeps_non_file_payloads(tmp_path: Path):
     service = AcpAgentService(SessionRegistry(), program="agent", args=[])
     response = AgentReply(
         text="ok",
@@ -1117,7 +1117,7 @@ def test_resolve_file_uri_resources_keeps_non_file_payloads(tmp_path: Path) -> N
     assert resolved.images == ()
 
 
-def test_resolve_file_uri_resources_reports_unreadable_file(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_file_uri_resources_reports_unreadable_file(tmp_path: Path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir(parents=True, exist_ok=True)
     file_path = workspace / "a.txt"
@@ -1138,7 +1138,7 @@ def test_resolve_file_uri_resources_reports_unreadable_file(tmp_path: Path, monk
     assert "Attachment warning: a.txt: unreadable file" in resolved.text
 
 
-def test_resolve_local_file_uri_validation(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_local_file_uri_validation(tmp_path: Path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir(parents=True, exist_ok=True)
     file_path = workspace / "ok.txt"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def isolate_token_sources(monkeypatch: pytest.MonkeyPatch, mocker):
     return mocker.patch("telegram_acp_bot.load_dotenv")
 
 
-def test_main_loads_dotenv(isolate_token_sources, mocker) -> None:
+def test_main_loads_dotenv(isolate_token_sources, mocker):
     """CLI loads .env before parsing arguments."""
     mocker.patch("telegram_acp_bot.run_polling", return_value=0)
     assert isolate_token_sources is not None
@@ -28,26 +28,26 @@ def test_main_loads_dotenv(isolate_token_sources, mocker) -> None:
     isolate_token_sources.assert_called_once_with(override=False)
 
 
-def test_main_requires_token() -> None:
+def test_main_requires_token():
     """Running the bot without token should fail fast."""
     with pytest.raises(SystemExit):
         main([])
 
 
-def test_main_requires_agent_command() -> None:
+def test_main_requires_agent_command():
     """Running the bot without ACP agent command should fail fast."""
     with pytest.raises(SystemExit):
         main(["--telegram-token", "TOKEN"])
 
 
-def test_main_runs_bot(mocker) -> None:
+def test_main_runs_bot(mocker):
     """Run path delegates to run_polling."""
     mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
     assert main(["--telegram-token", "TOKEN", "--agent-command", "agent --flag"]) == 0
     mock_run_polling.assert_called_once()
 
 
-def test_main_uses_env_token(mocker, monkeypatch) -> None:
+def test_main_uses_env_token(mocker, monkeypatch):
     """Run path uses TELEGRAM_BOT_TOKEN when loaded from environment."""
     mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "TOKEN")
@@ -56,21 +56,21 @@ def test_main_uses_env_token(mocker, monkeypatch) -> None:
     mock_run_polling.assert_called_once()
 
 
-def test_main_rejects_blank_agent_command(mocker) -> None:
+def test_main_rejects_blank_agent_command(mocker):
     """Whitespace-only agent command should be rejected."""
     mocker.patch("telegram_acp_bot.run_polling", return_value=0)
     with pytest.raises(SystemExit):
         main(["--telegram-token", "TOKEN", "--agent-command", "   "])
 
 
-def test_main_rejects_non_positive_stdio_limit(mocker) -> None:
+def test_main_rejects_non_positive_stdio_limit(mocker):
     """ACP stdio limit must be a positive integer."""
     mocker.patch("telegram_acp_bot.run_polling", return_value=0)
     with pytest.raises(SystemExit):
         main(["--telegram-token", "TOKEN", "--agent-command", "agent", "--acp-stdio-limit", "0"])
 
 
-def test_main_passes_stdio_limit_to_service(mocker) -> None:
+def test_main_passes_stdio_limit_to_service(mocker):
     """CLI forwards acp stdio limit to service constructor."""
     mock_service = mocker.patch("telegram_acp_bot.AcpAgentService")
     mocker.patch("telegram_acp_bot.run_polling", return_value=0)
@@ -92,7 +92,7 @@ def test_main_passes_stdio_limit_to_service(mocker) -> None:
     assert mock_service.call_args.kwargs["stdio_limit"] == CUSTOM_STDIO_LIMIT
 
 
-def test_show_help(capsys: pytest.CaptureFixture) -> None:
+def test_show_help(capsys: pytest.CaptureFixture):
     """Show help.
 
     Parameters:
@@ -104,7 +104,7 @@ def test_show_help(capsys: pytest.CaptureFixture) -> None:
     assert "acp-bot" in captured.out
 
 
-def test_show_version(mocker, capsys: pytest.CaptureFixture) -> None:
+def test_show_version(mocker, capsys: pytest.CaptureFixture):
     """Show version.
 
     Parameters:

--- a/tests/test_core_session_registry.py
+++ b/tests/test_core_session_registry.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from telegram_acp_bot.core.session_registry import SessionRegistry
 
 
-def test_registry_create_get_clear() -> None:
+def test_registry_create_get_clear():
     registry = SessionRegistry()
 
     session = registry.create_or_replace(chat_id=10, workspace=Path("/tmp"))
@@ -13,7 +13,7 @@ def test_registry_create_get_clear() -> None:
     assert registry.get(10) is None
 
 
-def test_registry_replace_existing_session() -> None:
+def test_registry_replace_existing_session():
     registry = SessionRegistry()
 
     first = registry.create_or_replace(chat_id=20, workspace=Path("/a"))

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -199,14 +199,14 @@ def make_bridge(*, allowed_ids: set[int] | None = None) -> TelegramBridge:
     return TelegramBridge(config=config, agent_service=EchoAgentService(SessionRegistry()))
 
 
-def test_make_config() -> None:
+def test_make_config():
     config = make_config(token="T", allowed_user_ids=[1, 2, 2], workspace="~/tmp")
     assert config.token == "T"
     assert config.allowed_user_ids == {1, 2}
     assert config.default_workspace.name == "tmp"
 
 
-def test_workspace_from_relative_arg_uses_default_workspace() -> None:
+def test_workspace_from_relative_arg_uses_default_workspace():
     config = make_config(token="T", allowed_user_ids=[], workspace="/tmp/base")
     bridge = TelegramBridge(config=config, agent_service=EchoAgentService(SessionRegistry()))
 
@@ -214,7 +214,7 @@ def test_workspace_from_relative_arg_uses_default_workspace() -> None:
     assert workspace == Path("/tmp/base/foo")
 
 
-def test_start_and_help() -> None:
+def test_start_and_help():
     bridge = make_bridge()
     update = make_update(with_message=True)
     context = make_context()
@@ -229,7 +229,7 @@ def test_start_and_help() -> None:
     assert "/perm" not in update.message.replies[1]
 
 
-def test_access_denied() -> None:
+def test_access_denied():
     bridge = make_bridge(allowed_ids={99})
     update = make_update(user_id=1)
     context = make_context()
@@ -240,7 +240,7 @@ def test_access_denied() -> None:
     assert update.message.replies == ["Access denied for this bot."]
 
 
-def test_access_allowed_with_allowlist() -> None:
+def test_access_allowed_with_allowlist():
     bridge = make_bridge(allowed_ids={1})
     update = make_update(user_id=1)
     context = make_context()
@@ -252,7 +252,7 @@ def test_access_allowed_with_allowlist() -> None:
     assert "Use /new" in update.message.replies[0]
 
 
-def test_denied_paths_for_other_handlers() -> None:
+def test_denied_paths_for_other_handlers():
     bridge = make_bridge(allowed_ids={42})
     update = make_update(user_id=7, text="hello")
     context = make_context()
@@ -277,7 +277,7 @@ def test_denied_paths_for_other_handlers() -> None:
     ]
 
 
-def test_new_session_and_session_command() -> None:
+def test_new_session_and_session_command():
     bridge = make_bridge()
     update = make_update()
 
@@ -291,7 +291,7 @@ def test_new_session_and_session_command() -> None:
     assert "Active session workspace:" in update.message.replies[2]
 
 
-def test_new_session_autocreates_relative_workspace_and_reports_it(tmp_path: Path) -> None:
+def test_new_session_autocreates_relative_workspace_and_reports_it(tmp_path: Path):
     config = make_config(token="TOKEN", allowed_user_ids=[], workspace=str(tmp_path))
     bridge = TelegramBridge(config=config, agent_service=EchoAgentService(SessionRegistry()))
     update = make_update()
@@ -305,7 +305,7 @@ def test_new_session_autocreates_relative_workspace_and_reports_it(tmp_path: Pat
     assert f"Created workspace: `{created_path}`" in update.message.replies[0]
 
 
-def test_new_session_reports_invalid_workspace() -> None:
+def test_new_session_reports_invalid_workspace():
     class InvalidWorkspaceService:
         async def new_session(self, *, chat_id: int, workspace):
             del chat_id, workspace
@@ -327,7 +327,7 @@ def test_new_session_reports_invalid_workspace() -> None:
     assert update.message.replies == ["Invalid workspace: /missing"]
 
 
-def test_new_session_reports_process_stdio_error() -> None:
+def test_new_session_reports_process_stdio_error():
     class BrokenAgentService:
         async def new_session(self, *, chat_id: int, workspace):
             del chat_id, workspace
@@ -349,7 +349,7 @@ def test_new_session_reports_process_stdio_error() -> None:
     assert update.message.replies == ["Failed to start session: agent process did not expose stdio pipes."]
 
 
-def test_new_session_reports_generic_error() -> None:
+def test_new_session_reports_generic_error():
     class BoomError(Exception):
         pass
 
@@ -374,7 +374,7 @@ def test_new_session_reports_generic_error() -> None:
     assert update.message.replies == ["Failed to start session: boom"]
 
 
-def test_on_text_without_and_with_session() -> None:
+def test_on_text_without_and_with_session():
     bridge = make_bridge()
     update = make_update(text="hello")
     context = make_context()
@@ -390,7 +390,7 @@ def test_on_text_without_and_with_session() -> None:
     assert update.message.reply_kwargs[-1] == {"parse_mode": "Markdown"}
 
 
-def test_on_text_markdown_fallback_to_plain() -> None:
+def test_on_text_markdown_fallback_to_plain():
     bridge = make_bridge()
     update = make_update(text="hello")
     assert update.message is not None
@@ -405,7 +405,7 @@ def test_on_text_markdown_fallback_to_plain() -> None:
     assert update.message.reply_kwargs[-1] == {}
 
 
-def test_on_message_with_photo_attachment() -> None:
+def test_on_message_with_photo_attachment():
     bridge = make_bridge()
     photo = [SimpleNamespace(file_id="p1")]
     update = make_update(photo=photo)
@@ -419,7 +419,7 @@ def test_on_message_with_photo_attachment() -> None:
     assert "images=1" in update.message.replies[-1]
 
 
-def test_on_message_with_document_attachment() -> None:
+def test_on_message_with_document_attachment():
     bridge = make_bridge()
     document = SimpleNamespace(file_id="d1", mime_type="text/plain", file_name="note.txt")
     update = make_update(document=document)
@@ -433,7 +433,7 @@ def test_on_message_with_document_attachment() -> None:
     assert "files=1" in update.message.replies[-1]
 
 
-def test_on_message_with_binary_document_attachment() -> None:
+def test_on_message_with_binary_document_attachment():
     bridge = make_bridge()
     document = SimpleNamespace(file_id="bin-doc", mime_type="application/octet-stream", file_name="x.bin")
     update = make_update(document=document)
@@ -447,7 +447,7 @@ def test_on_message_with_binary_document_attachment() -> None:
     assert "files=1" in update.message.replies[-1]
 
 
-def test_on_message_with_image_document_attachment() -> None:
+def test_on_message_with_image_document_attachment():
     bridge = make_bridge()
     document = SimpleNamespace(file_id="img-doc", mime_type="image/png", file_name="x.png")
     update = make_update(document=document)
@@ -461,7 +461,7 @@ def test_on_message_with_image_document_attachment() -> None:
     assert "images=1" in update.message.replies[-1]
 
 
-def test_outbound_agent_attachments_are_sent() -> None:
+def test_outbound_agent_attachments_are_sent():
     class AttachmentService:
         async def new_session(self, *, chat_id: int, workspace):
             del workspace
@@ -516,7 +516,7 @@ def test_outbound_agent_attachments_are_sent() -> None:
     assert len(update.message.documents) == EXPECTED_OUTBOUND_DOCUMENTS
 
 
-def test_on_message_renders_activity_blocks_before_final_reply() -> None:
+def test_on_message_renders_activity_blocks_before_final_reply():
     class ActivityService:
         async def new_session(self, *, chat_id: int, workspace):
             del workspace
@@ -582,7 +582,7 @@ def test_on_message_renders_activity_blocks_before_final_reply() -> None:
     assert update.message.replies[2] == "Done."
 
 
-def test_on_message_sends_live_activity_events_via_app_bot() -> None:
+def test_on_message_sends_live_activity_events_via_app_bot():
     service = LiveActivityService()
     config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")
     bridge = TelegramBridge(config=config, agent_service=cast(AgentService, service))
@@ -598,7 +598,7 @@ def test_on_message_sends_live_activity_events_via_app_bot() -> None:
     assert "*💡 Thinking*" in cast(str, context.bot.sent_messages[0]["text"])
 
 
-def test_on_message_skips_empty_final_text_reply() -> None:
+def test_on_message_skips_empty_final_text_reply():
     class EmptyTextService:
         async def new_session(self, *, chat_id: int, workspace):
             del workspace
@@ -645,7 +645,7 @@ def test_on_message_skips_empty_final_text_reply() -> None:
     assert update.message.replies == []
 
 
-def test_on_message_reports_acp_stdio_limit_error() -> None:
+def test_on_message_reports_acp_stdio_limit_error():
     class LimitErrorService:
         async def new_session(self, *, chat_id: int, workspace):
             del workspace
@@ -692,7 +692,7 @@ def test_on_message_reports_acp_stdio_limit_error() -> None:
     assert "Agent output exceeded ACP stdio limit." in update.message.replies[-1]
 
 
-def test_on_message_reraises_unrelated_value_error() -> None:
+def test_on_message_reraises_unrelated_value_error():
     class GenericValueErrorService:
         async def new_session(self, *, chat_id: int, workspace):
             del workspace
@@ -737,13 +737,13 @@ def test_on_message_reraises_unrelated_value_error() -> None:
         asyncio.run(bridge.on_message(update, context))
 
 
-def test_on_activity_event_without_app_is_noop() -> None:
+def test_on_activity_event_without_app_is_noop():
     bridge = make_bridge()
     block = AgentActivityBlock(kind="think", title="x", status="completed", text="y")
     asyncio.run(bridge.on_activity_event(TEST_CHAT_ID, block))
 
 
-def test_on_activity_event_markdown_fallback() -> None:
+def test_on_activity_event_markdown_fallback():
     bridge = make_bridge()
     failing_bot = FailingMarkdownBot()
     bridge._app = cast(Application, SimpleNamespace(bot=failing_bot))
@@ -755,7 +755,7 @@ def test_on_activity_event_markdown_fallback() -> None:
     assert "parse_mode" not in failing_bot.sent_messages[-1]
 
 
-def test_format_activity_block_read_escapes_markdown_and_removes_read_prefix() -> None:
+def test_format_activity_block_read_escapes_markdown_and_removes_read_prefix():
     block = AgentActivityBlock(
         kind="read", title="Read test_telegram_bot.py", status="completed", text="Read test_telegram_bot.py"
     )
@@ -765,7 +765,7 @@ def test_format_activity_block_read_escapes_markdown_and_removes_read_prefix() -
     assert "\n\nRead test\\_telegram\\_bot.py" not in rendered
 
 
-def test_format_activity_block_preserves_thinking_inline_code() -> None:
+def test_format_activity_block_preserves_thinking_inline_code():
     block = AgentActivityBlock(
         kind="think",
         title="",
@@ -777,13 +777,13 @@ def test_format_activity_block_preserves_thinking_inline_code() -> None:
     assert "`docs/index.md`" in rendered
 
 
-def test_format_activity_block_execute_wraps_command_as_inline_code() -> None:
+def test_format_activity_block_execute_wraps_command_as_inline_code():
     block = AgentActivityBlock(kind="execute", title="Run git diff -- README.md docs/index.md", status="in_progress")
     rendered = TelegramBridge._format_activity_block(block)
     assert "Run `git diff -- README.md docs/index.md`" in rendered
 
 
-def test_send_helpers_with_no_message() -> None:
+def test_send_helpers_with_no_message():
     update = make_update(with_message=False)
     image = ImagePayload(data_base64=base64.b64encode(b"img").decode("ascii"), mime_type="image/jpeg")
     file_payload = FilePayload(name="out.txt", text_content="content")
@@ -792,13 +792,13 @@ def test_send_helpers_with_no_message() -> None:
     asyncio.run(TelegramBridge._send_file(update, file_payload))
 
 
-def test_reply_activity_block_with_no_message_is_noop() -> None:
+def test_reply_activity_block_with_no_message_is_noop():
     update = make_update(with_message=False)
     block = AgentActivityBlock(kind="think", title="t", status="completed", text="x")
     asyncio.run(TelegramBridge._reply_activity_block(update, block))
 
 
-def test_reply_activity_block_failed_status_with_markdown_fallback() -> None:
+def test_reply_activity_block_failed_status_with_markdown_fallback():
     update = make_update()
     assert update.message is not None
     update.message.fail_markdown = True
@@ -811,7 +811,7 @@ def test_reply_activity_block_failed_status_with_markdown_fallback() -> None:
     assert update.message.reply_kwargs[-1] == {}
 
 
-def test_send_file_with_empty_payload() -> None:
+def test_send_file_with_empty_payload():
     update = make_update()
     assert update.message is not None
     payload = FilePayload(name="empty.bin")
@@ -819,7 +819,7 @@ def test_send_file_with_empty_payload() -> None:
     assert len(update.message.documents) == 1
 
 
-def test_on_permission_request_sends_buttons() -> None:
+def test_on_permission_request_sends_buttons():
     bridge = make_bridge()
     dummy_bot = DummyBot()
     bridge._app = cast(Application, SimpleNamespace(bot=dummy_bot))
@@ -841,7 +841,7 @@ def test_on_permission_request_sends_buttons() -> None:
     assert markup is not None
 
 
-def test_on_permission_request_without_app_is_noop() -> None:
+def test_on_permission_request_without_app_is_noop():
     bridge = make_bridge()
     request = PermissionRequest(
         chat_id=TEST_CHAT_ID,
@@ -853,7 +853,7 @@ def test_on_permission_request_without_app_is_noop() -> None:
     asyncio.run(bridge.on_permission_request(request))
 
 
-def test_on_permission_callback_accepts_action() -> None:
+def test_on_permission_callback_accepts_action():
     class PermissionService:
         def set_permission_request_handler(self, handler):
             del handler
@@ -883,7 +883,7 @@ def test_on_permission_callback_accepts_action() -> None:
     assert "Decision: Approved this time." in callback.edited_text
 
 
-def test_on_permission_callback_invalid_cases() -> None:
+def test_on_permission_callback_invalid_cases():
     bridge = make_bridge()
     update_no_query = cast(
         Update,
@@ -937,7 +937,7 @@ def test_on_permission_callback_invalid_cases() -> None:
     assert callback_missing_chat.answers[-1] == "Missing chat."
 
 
-def test_on_permission_callback_access_denied() -> None:
+def test_on_permission_callback_access_denied():
     bridge = make_bridge(allowed_ids={9})
     callback = DummyCallbackQuery("perm|req1|deny")
     update = cast(
@@ -953,7 +953,7 @@ def test_on_permission_callback_access_denied() -> None:
     assert callback.answers[-1] == "Access denied."
 
 
-def test_on_permission_callback_expired_request() -> None:
+def test_on_permission_callback_expired_request():
     class ExpiredService:
         def set_permission_request_handler(self, handler):
             del handler
@@ -981,7 +981,7 @@ def test_on_permission_callback_expired_request() -> None:
     assert callback.answers[-1] == "Request expired."
 
 
-def test_on_permission_callback_fallback_to_clear_markup_on_edit_error() -> None:
+def test_on_permission_callback_fallback_to_clear_markup_on_edit_error():
     class PermissionService:
         def set_permission_request_handler(self, handler):
             del handler
@@ -1015,7 +1015,7 @@ def test_on_permission_callback_fallback_to_clear_markup_on_edit_error() -> None
     assert callback.reply_markup_cleared
 
 
-def test_on_permission_callback_uses_query_message_chat_when_effective_chat_missing() -> None:
+def test_on_permission_callback_uses_query_message_chat_when_effective_chat_missing():
     class PermissionService:
         def set_permission_request_handler(self, handler):
             del handler
@@ -1048,7 +1048,7 @@ def test_on_permission_callback_uses_query_message_chat_when_effective_chat_miss
     assert "Decision: Approved this time." in callback.edited_text
 
 
-def test_on_permission_callback_handles_unexpected_exception() -> None:
+def test_on_permission_callback_handles_unexpected_exception():
     class FailingService:
         def set_permission_request_handler(self, handler):
             del handler
@@ -1076,7 +1076,7 @@ def test_on_permission_callback_handles_unexpected_exception() -> None:
     assert callback.answers[-1] == "Permission action failed."
 
 
-def test_cancel_stop_clear_without_session() -> None:
+def test_cancel_stop_clear_without_session():
     bridge = make_bridge()
     update = make_update()
     context = make_context()
@@ -1093,7 +1093,7 @@ def test_cancel_stop_clear_without_session() -> None:
     ]
 
 
-def test_cancel_stop_clear_with_session() -> None:
+def test_cancel_stop_clear_with_session():
     bridge = make_bridge()
     update = make_update()
 
@@ -1111,7 +1111,7 @@ def test_cancel_stop_clear_with_session() -> None:
     ]
 
 
-def test_clear_with_session() -> None:
+def test_clear_with_session():
     bridge = make_bridge()
     update = make_update()
 
@@ -1123,7 +1123,7 @@ def test_clear_with_session() -> None:
     assert update.message.replies[1] == "Cleared current session."
 
 
-def test_on_text_ignores_empty_message() -> None:
+def test_on_text_ignores_empty_message():
     bridge = make_bridge()
     update = make_update(text=None)
     context = make_context()
@@ -1135,19 +1135,19 @@ def test_on_text_ignores_empty_message() -> None:
     assert context.bot.actions == []
 
 
-def test_reply_with_no_message_object() -> None:
+def test_reply_with_no_message_object():
     bridge = make_bridge()
     update = make_update(with_message=False)
 
     asyncio.run(bridge.help(update, make_context()))
 
 
-def test_reply_agent_with_no_message_object() -> None:
+def test_reply_agent_with_no_message_object():
     update = make_update(with_message=False)
     asyncio.run(TelegramBridge._reply_agent(update, "x"))
 
 
-def test_on_text_ignores_when_message_is_missing() -> None:
+def test_on_text_ignores_when_message_is_missing():
     bridge = make_bridge()
     update = make_update(with_message=False)
     context = make_context()
@@ -1156,13 +1156,13 @@ def test_on_text_ignores_when_message_is_missing() -> None:
     assert context.bot.actions == []
 
 
-def test_chat_id_without_chat_raises() -> None:
+def test_chat_id_without_chat_raises():
     update = cast(Update, SimpleNamespace(effective_chat=None))
     with pytest.raises(ChatRequiredError):
         TelegramBridge._chat_id(update)
 
 
-def test_build_application_installs_handlers() -> None:
+def test_build_application_installs_handlers():
     bridge = make_bridge()
     config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")
 
@@ -1171,7 +1171,7 @@ def test_build_application_installs_handlers() -> None:
     assert app.update_processor.max_concurrent_updates > 1
 
 
-def test_run_polling(monkeypatch) -> None:
+def test_run_polling(monkeypatch):
     calls: list[object] = []
 
     class DummyApp:


### PR DESCRIPTION
## Summary
- remove `-> None` from `test_*` function signatures across test files
- keep behavior unchanged (style-only cleanup)

## Why
- test return annotations are redundant in this project style
- reduces noise and improves readability in large test modules

## Validation
- `uv run ruff check src tests`
- `uv run pytest -q`
