### PR TITLE
Harden ACP stdio limit handling with typed exception

### DIFF
--- a/src/telegram_acp_bot/acp_app/models.py
+++ b/src/telegram_acp_bot/acp_app/models.py
@@ -82,3 +82,7 @@ class PermissionRequest:
     tool_title: str
     tool_call_id: str
     available_actions: tuple[PermissionDecisionAction, ...]
+
+
+class AgentOutputLimitExceededError(RuntimeError):
+    """Raised when the agent emits a stdio line larger than the configured reader limit."""

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -12,7 +12,14 @@ from telegram.error import TelegramError
 from telegram.ext import Application
 
 from telegram_acp_bot.acp_app.echo_service import EchoAgentService
-from telegram_acp_bot.acp_app.models import AgentActivityBlock, AgentReply, FilePayload, ImagePayload, PermissionRequest
+from telegram_acp_bot.acp_app.models import (
+    AgentActivityBlock,
+    AgentOutputLimitExceededError,
+    AgentReply,
+    FilePayload,
+    ImagePayload,
+    PermissionRequest,
+)
 from telegram_acp_bot.core.session_registry import SessionRegistry
 from telegram_acp_bot.telegram import bot as bot_module
 from telegram_acp_bot.telegram.bot import (
@@ -654,7 +661,7 @@ async def test_on_message_reports_acp_stdio_limit_error():
 
         async def prompt(self, *, chat_id: int, text: str, images=(), files=()):
             del chat_id, text, images, files
-            raise ValueError(ACP_STDIO_LIMIT_ERROR)
+            raise AgentOutputLimitExceededError(ACP_STDIO_LIMIT_ERROR)
 
         def get_workspace(self, *, chat_id: int):
             del chat_id


### PR DESCRIPTION
## Summary
- introduce AgentOutputLimitExceededError in app models
- wrap ACP stdio overrun failures in AcpAgentService.prompt with the typed exception
- handle the typed exception in TelegramBridge.on_message instead of string-matching a ValueError
- keep unrelated ValueError paths untouched (re-raised)
- add tests for both wrapped and pass-through paths

## Why
- removes fragile string matching in error handling
- makes bot/service contract explicit and easier to maintain

## Validation
- uv run ruff check src tests
- uv run pytest -q
