### PR TITLE
docs: add configuration glossary and CLI reference

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,49 @@
+# CLI Reference
+
+The bot entrypoint is `acp-bot`.
+
+```{richterm} env PYTHONPATH=../src uv run -m telegram_acp_bot --help
+:hide-command: true
+```
+
+## Arguments
+
+- `--telegram-token`
+  Default: {term}`TELEGRAM_BOT_TOKEN`.
+  Required if {term}`TELEGRAM_BOT_TOKEN` is not set.
+
+- `--agent-command`
+  Default: {term}`ACP_AGENT_COMMAND`.
+  Required if {term}`ACP_AGENT_COMMAND` is not set.
+
+- `--restart-command`
+  Default: {term}`ACP_RESTART_COMMAND`.
+  Optional command used by `/restart` to relaunch the process.
+
+- `--allowed-user-id`
+  Repeatable allowlist of Telegram user IDs.
+  If omitted, the bot accepts messages from any user.
+
+- `--workspace`
+  Default workspace used by `/new` when no workspace path is provided.
+
+- `--permission-mode`
+  Default: {term}`ACP_PERMISSION_MODE`.
+  Allowed values: `ask`, `approve`, `deny`.
+
+- `--permission-event-output`
+  Default: {term}`ACP_PERMISSION_EVENT_OUTPUT`.
+  Allowed values: `stdout`, `off`.
+
+- `--acp-stdio-limit`
+  Default: {term}`ACP_STDIO_LIMIT`.
+  Asyncio stdio reader limit in bytes.
+
+- `-V`, `--version`
+  Print CLI version and exit.
+
+## Notes
+
+- `/restart` behavior:
+  - If {term}`ACP_RESTART_COMMAND` (or `--restart-command`) is set, that command is executed.
+  - Otherwise, the bot re-execs itself using `sys.executable + sys.argv`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,49 @@
+# Configuration
+
+This page documents runtime configuration via environment variables.
+
+```{glossary}
+TELEGRAM_BOT_TOKEN
+  Telegram bot token (from BotFather). Required unless passed as `--telegram-token`.
+
+ACP_AGENT_COMMAND
+  Command line used to launch the ACP agent process.
+  Examples: `npx @zed-industries/codex-acp`, `uv run examples/echo_agent.py`.
+  Required unless passed as `--agent-command`.
+
+ACP_RESTART_COMMAND
+  Optional command used by `/restart` to relaunch the bot process.
+  Recommended when you run with `uv run ...` and need to preserve its flags.
+  Example: `uv run acp-bot --telegram-token ... --agent-command ...`.
+
+ACP_PERMISSION_MODE
+  Default permission policy for ACP tool calls.
+  Allowed values: `ask`, `approve`, `deny`.
+  Maps to `--permission-mode`.
+
+ACP_PERMISSION_EVENT_OUTPUT
+  Permission/tool event log output mode.
+  Allowed values: `stdout`, `off`.
+  Maps to `--permission-event-output`.
+
+ACP_STDIO_LIMIT
+  Asyncio stdio reader limit in bytes for ACP transport.
+  Increase this if the agent emits very large JSON lines.
+  Maps to `--acp-stdio-limit`.
+
+ACP_LOG_LEVEL
+  Application log level.
+  Common values: `DEBUG`, `INFO`, `WARNING`, `ERROR`.
+```
+
+## Example `.env`
+
+```ini
+TELEGRAM_BOT_TOKEN=123456:abc
+ACP_AGENT_COMMAND="npx @zed-industries/codex-acp"
+ACP_RESTART_COMMAND="uv run acp-bot --telegram-token 123456:abc --agent-command \"npx @zed-industries/codex-acp\""
+ACP_PERMISSION_MODE=ask
+ACP_PERMISSION_EVENT_OUTPUT=stdout
+ACP_STDIO_LIMIT=8388608
+ACP_LOG_LEVEL=INFO
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,8 @@ Permission behavior:
 :maxdepth: 2
 :caption: Documentation
 
+configuration.md
+cli.md
 ../CONTRIBUTING.md
 ../CODE_OF_CONDUCT.md
 about_the_docs.md


### PR DESCRIPTION
## Summary
- add `docs/configuration.md` with a Sphinx glossary for runtime env vars
- add `docs/cli.md` with CLI argument reference and richterm help capture
- link CLI argument docs to glossary terms
- include both pages in docs toctree

## Validation
- `make docs`
