### PR TITLE
docs: add GitHub Copilot ACP setup to agents guide

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,6 +9,7 @@ Use {term}`ACP_AGENT_COMMAND` to define the command executed by `/new`.
 | Agent | ACP support | Recommended command |
 | --- | --- | --- |
 | [Gemini CLI](https://google-gemini.github.io/gemini-cli/) | Native ACP support (experimental flag required) | `ACP_AGENT_COMMAND="npx @google/gemini-cli --experimental-acp"` |
+| GitHub Copilot CLI | Native ACP support (`--acp`) | `ACP_AGENT_COMMAND="copilot --acp"` |
 | [Codex CLI](https://developers.openai.com/codex/cli) | Via ACP adapter | `ACP_AGENT_COMMAND="npx @zed-industries/codex-acp"` |
 | [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) / [Claude Code](https://code.claude.com/docs/en/cli-reference) | Via ACP adapter | `ACP_AGENT_COMMAND="npx @zed-industries/claude-agent-acp"` |
 
@@ -38,6 +39,15 @@ uv run acp-bot
 ```
 
 You can also install the adapter binary from [adapter releases](https://github.com/zed-industries/codex-acp/releases) and use `codex-acp` directly.
+
+## GitHub Copilot CLI (native ACP)
+
+If you already have Copilot CLI installed and authenticated, run:
+
+```bash
+ACP_AGENT_COMMAND="copilot --acp" \
+uv run acp-bot
+```
 
 ## Claude Agent / Claude Code (via adapter)
 


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI to the agent compatibility table in `docs/agents.md`
- document `ACP_AGENT_COMMAND="copilot --acp"` usage in a dedicated section

## Verification
- `make docs`
