### PR TITLE
fix: split multi-Run execute titles into per-command code spans

### DIFF
--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -655,6 +655,10 @@ class TelegramBridge:
             if command:
                 if "\n" in command:
                     return f"Run\n```sh\n{command}\n```"
+                if ", Run " in command:
+                    commands = [part.strip() for part in command.split(", Run ")]
+                    if commands and all(commands):
+                        return ", ".join(f"Run `{cmd.replace('`', '\\`')}`" for cmd in commands)
                 safe_command = command.replace("`", "\\`")
                 return f"Run `{safe_command}`"
         path_prefix = TelegramBridge._path_prefix_for_kind(block.kind)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1062,6 +1062,17 @@ async def test_format_activity_block_execute_multiline_command_uses_fenced_code_
     assert "Run\n```sh\ngit diff -- README.md \\\n  docs/index.md\n```" in rendered
 
 
+async def test_format_activity_block_execute_multiple_run_segments_are_wrapped_individually():
+    block = AgentActivityBlock(
+        kind="execute",
+        title="Run which ffmpeg, Run ffmpeg -y -f x11grab -i :0.0 -frames:v 1 /tmp/screenshot-ffmpeg.png",
+        status="in_progress",
+    )
+    rendered = TelegramBridge._format_activity_block(block)
+    assert "Run `which ffmpeg`, Run `ffmpeg -y -f x11grab -i :0.0 -frames:v 1 /tmp/screenshot-ffmpeg.png`" in rendered
+    assert "Run `which ffmpeg, Run ffmpeg -y -f x11grab -i :0.0 -frames:v 1 /tmp/screenshot-ffmpeg.png`" not in rendered
+
+
 async def test_send_helpers_with_no_message():
     update = make_update(with_message=False)
     image = ImagePayload(data_base64=base64.b64encode(b"img").decode("ascii"), mime_type="image/jpeg")


### PR DESCRIPTION
## Summary
- update Telegram execute title formatting for strings like `Run cmd1, Run cmd2`
- render each command as its own inline code span instead of wrapping the whole combined title
- add regression test for the multi-Run formatting case

## Verification
- `uv run ruff check src/telegram_acp_bot/telegram/bot.py tests/test_telegram_bot.py`
- `uv run pytest`

Closes #57
