### PR TITLE
fix: align permission actions with ACP option kinds

### DIFF
--- a/src/telegram_acp_bot/acp_app/acp_service.py
+++ b/src/telegram_acp_bot/acp_app/acp_service.py
@@ -649,6 +649,17 @@ class AcpAgentService:
             )
             return False
 
+        available_actions = self._available_actions(pending.options)
+        if action not in available_actions:
+            logger.warning(
+                "Permission response rejected: unavailable action request_id=%s chat_id=%s action=%s available=%s",
+                request_id,
+                chat_id,
+                action,
+                ",".join(available_actions),
+            )
+            return False
+
         response = self._build_permission_response(
             options=pending.options,
             action=action,
@@ -789,7 +800,8 @@ class AcpAgentService:
             if live.acp_session_id != session_id:
                 continue
             if live.permission_mode == "approve" or live.active_prompt_auto_approve:
-                return self._build_permission_response(options=tuple(options), action="once")
+                auto_action = self._auto_approve_action(tuple(options))
+                return self._build_permission_response(options=tuple(options), action=auto_action)
             if live.permission_mode == "deny":
                 return self._build_permission_response(options=tuple(options), action="deny")
 
@@ -831,10 +843,10 @@ class AcpAgentService:
     def _available_actions(options: tuple[PermissionOption, ...]) -> tuple[PermissionDecisionAction, ...]:
         kinds = {option.kind for option in options}
         actions: list[PermissionDecisionAction] = []
-        if "allow_once" in kinds or "allow_always" in kinds:
-            actions.append("once")
         if "allow_always" in kinds:
             actions.append("always")
+        if "allow_once" in kinds:
+            actions.append("once")
         actions.append("deny")
         return tuple(actions)
 
@@ -847,14 +859,20 @@ class AcpAgentService:
         if action == "deny":
             return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
 
-        preferred_kinds = ("allow_always", "allow_once") if action == "always" else ("allow_once", "allow_always")
-        for kind in preferred_kinds:
-            for option in options:
-                if option.kind == kind:
-                    return RequestPermissionResponse(
-                        outcome=AllowedOutcome(option_id=option.option_id, outcome="selected")
-                    )
+        target_kind = "allow_always" if action == "always" else "allow_once"
+        for option in options:
+            if option.kind == target_kind:
+                return RequestPermissionResponse(outcome=AllowedOutcome(option_id=option.option_id, outcome="selected"))
         return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+
+    @staticmethod
+    def _auto_approve_action(options: tuple[PermissionOption, ...]) -> PermissionDecisionAction:
+        kinds = {option.kind for option in options}
+        if "allow_once" in kinds:
+            return "once"
+        if "allow_always" in kinds:
+            return "always"
+        return "deny"
 
     def _report_permission_event(self, event: str) -> None:
         if self._permission_event_output == "stdout":

--- a/tests/test_acp_service.py
+++ b/tests/test_acp_service.py
@@ -1315,6 +1315,55 @@ async def test_respond_permission_request_rejects_unknown_request(tmp_path: Path
     assert not await service.respond_permission_request(chat_id=1, request_id="missing", action="deny")
 
 
+async def test_respond_permission_request_rejects_unavailable_action(tmp_path: Path):
+    del tmp_path
+    service = AcpAgentService(SessionRegistry(), program="agent", args=[])
+    future: asyncio.Future[RequestPermissionResponse] = asyncio.get_running_loop().create_future()
+    service._pending_permissions["req-1"] = _PendingPermission(
+        request_id="req-1",
+        chat_id=1,
+        acp_session_id="s-1",
+        tool_title="Run",
+        tool_call_id="tc-1",
+        options=(PermissionOption(kind="allow_once", name="Allow once", option_id="opt-once"),),
+        future=future,
+    )
+
+    accepted = await service.respond_permission_request(chat_id=1, request_id="req-1", action="always")
+    assert accepted is False
+    assert not future.done()
+
+
+async def test_decide_permission_auto_approve_supports_allow_always_only(tmp_path: Path):
+    process = FakeProcess()
+    connection = FakeConnection(session_id="approve-always-only")
+
+    async def fake_spawn(program: str, *args: str, **kwargs):
+        del program, args, kwargs
+        return process
+
+    def fake_connect(client, input_stream, output_stream):
+        del input_stream, output_stream
+        connection.client = client
+        return connection
+
+    service = AcpAgentService(
+        SessionRegistry(),
+        program="agent",
+        args=[],
+        spawner=fake_spawn,
+        connector=fake_connect,
+    )
+    await service.new_session(chat_id=1, workspace=tmp_path)
+    live = service._live_by_chat[1]
+    live.permission_mode = "approve"
+
+    option = PermissionOption(kind="allow_always", name="Always", option_id="opt-always")
+    tool_call = ToolCall(title="run", tool_call_id="tc-auto-always")
+    response = await service._decide_permission("approve-always-only", [option], tool_call)
+    assert response.outcome.outcome == "selected"
+
+
 async def test_stop_cancels_pending_permission_requests(tmp_path: Path):
     process = FakeProcess()
     connection = FakeConnection(session_id="pending")
@@ -1400,6 +1449,34 @@ async def test_build_permission_response_fallbacks():
 
     fallback = AcpAgentService._build_permission_response(options=(), action="once")
     assert fallback.outcome.outcome == "cancelled"
+
+    no_once = AcpAgentService._build_permission_response(
+        options=(PermissionOption(kind="allow_always", name="Always", option_id="opt-always"),),
+        action="once",
+    )
+    assert no_once.outcome.outcome == "cancelled"
+
+    no_always = AcpAgentService._build_permission_response(
+        options=(PermissionOption(kind="allow_once", name="Allow once", option_id="opt-once"),),
+        action="always",
+    )
+    assert no_always.outcome.outcome == "cancelled"
+
+
+async def test_available_actions_reflect_agent_options():
+    both = (
+        PermissionOption(kind="allow_once", name="Allow once", option_id="opt-once"),
+        PermissionOption(kind="allow_always", name="Always", option_id="opt-always"),
+    )
+    assert AcpAgentService._available_actions(both) == ("always", "once", "deny")
+
+    always_only = (PermissionOption(kind="allow_always", name="Always", option_id="opt-always"),)
+    assert AcpAgentService._available_actions(always_only) == ("always", "deny")
+
+    once_only = (PermissionOption(kind="allow_once", name="Allow once", option_id="opt-once"),)
+    assert AcpAgentService._available_actions(once_only) == ("once", "deny")
+
+    assert AcpAgentService._auto_approve_action(()) == "deny"
 
 
 async def test_report_permission_event_respects_output_mode(caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
## Summary
- make available permission actions reflect actual ACP option kinds (`allow_once` vs `allow_always`)
- reject callback actions that were not offered for that request
- make auto-approve choose the best available ACP option kind instead of forcing `once`
- add regression tests for action availability and unavailable-action rejection

## Why
Prevents UX mismatches where Telegram labels could imply one decision while ACP accepted a different option kind.

## Verification
- `uv run ruff check src/telegram_acp_bot/acp_app/acp_service.py tests/test_acp_service.py`
- `uv run pytest`

Closes #56
