### PR TITLE
fix(telegram): compact execute tool-call rendering as Running

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ Attachment behavior:
 
 Tool activity behavior:
 - ACP tool updates are emitted as separate Telegram messages grouped by tool kind (`think`, `execute`, `read`, etc.).
-- Labels currently used in chat are: `💡 Thinking`, `⚙️ Tool call`, `📖 Reading`, `✏️ Editing`, and `🔎 Searching`.
+- Labels currently used in chat are: `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, and `🔎 Searching`.
 - Permission prompts for risky actions are sent as independent messages with inline buttons.
 - The final assistant answer is sent as a separate message after those activity blocks.
 - If the final text payload is empty, no dummy "(no text response)" message is emitted.

--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -312,11 +312,7 @@ class TelegramBridge:
             return
 
         keyboard = self._permission_keyboard(request)
-        title = TelegramBridge._format_permission_tool_title(request.tool_title)
-        message_parts = ["Permission required"]
-        if title:
-            message_parts.append(TelegramBridge._render_activity_part(title))
-        message = "\n\n".join(message_parts)
+        message = TelegramBridge._format_permission_request_text(request.tool_title)
         await TelegramBridge._send_markdown_to_chat(
             bot=self._app.bot,
             chat_id=request.chat_id,
@@ -846,6 +842,14 @@ class TelegramBridge:
                 AgentActivityBlock(kind="execute", title=title, status="in_progress")
             )
         return title
+
+    @staticmethod
+    def _format_permission_request_text(tool_title: str) -> str:
+        title = TelegramBridge._format_permission_tool_title(tool_title)
+        message_parts = ["*⚠️ Permission required*"]
+        if title:
+            message_parts.append(TelegramBridge._render_activity_part(title))
+        return "\n\n".join(message_parts)
 
     @staticmethod
     def _split_execute_commands(command: str) -> list[str]:

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1369,7 +1369,7 @@ async def test_on_permission_request_sends_buttons():
     assert len(dummy_bot.sent_messages) == 1
     payload = dummy_bot.sent_messages[0]
     assert payload["chat_id"] == TEST_CHAT_ID
-    assert cast(str, payload["text"]).startswith("Permission required")
+    assert cast(str, payload["text"]).startswith("⚠️ Permission required")
     assert cast(str, payload["text"]).endswith("ls")
     assert "parse_mode" not in payload
     assert "entities" in payload
@@ -1414,7 +1414,7 @@ async def test_on_permission_request_markdown_fallback_uses_plain_text():
 
     assert len(failing_bot.sent_messages) == 1
     payload = failing_bot.sent_messages[0]
-    assert payload["text"] == "Permission required\n\nls"
+    assert payload["text"] == "⚠️ Permission required\n\nls"
     assert "parse_mode" not in payload
     assert "entities" not in payload
 


### PR DESCRIPTION
Closes #76

## Summary
- Rename execute activity label from `⚙️ Tool call` to `⚙️ Running`
- Remove the standalone `Run` line from execute blocks
- Render multiple execute commands as consecutive fenced code blocks (no separator text)

## Validation
- `uv run --only-group lint ruff check`
- `uv run --only-group lint ruff format --check`
- `uv run --group qa ty check --output-format=github`
- `uv run pytest -q`
