### PR TITLE
fix(telegram): label local lookups as querying

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Attachment behavior:
 
 Tool activity behavior:
 - ACP tool updates are emitted as separate Telegram messages grouped by tool kind (`think`, `execute`, `read`, etc.).
-- Labels currently used in chat are: `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, and `🌐 Searching`.
+- Labels currently used in chat are: `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, and `🔎 Querying`.
 - Search activity blocks render compact details when available (`Query: "..."` and `URL: ...`) extracted from block title/text.
 - Permission prompts for risky actions are sent as independent messages with inline buttons.
 - The final assistant answer is sent as a separate message after those activity blocks.

--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -60,7 +60,7 @@ KIND_LABELS = {
     "think": "💡 Thinking",
     "execute": "⚙️ Running",
     "read": "📖 Reading",
-    "search": "🌐 Searching",
+    "search": "🔎 Querying",
     "edit": "✏️ Editing",
     "write": "✍️ Writing",
 }

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1478,7 +1478,7 @@ async def test_format_activity_block_read_prefers_file_uri_path():
 async def test_format_activity_block_search_uses_specific_label_not_tool_call():
     block = AgentActivityBlock(kind="search", title="Searching the Web", status="in_progress")
     rendered = TelegramBridge._format_activity_block(block)
-    assert "*🌐 Searching*" in rendered
+    assert "*🔎 Querying*" in rendered
     assert "Tool call" not in rendered
     assert "\n\nSearching the Web" not in rendered
 
@@ -1509,7 +1509,7 @@ async def test_format_activity_block_search_omits_generic_body_text():
         text="Searching the Web",
     )
     rendered = TelegramBridge._format_activity_block(block)
-    assert "*🌐 Searching*" in rendered
+    assert "*🔎 Querying*" in rendered
     assert "\n\nSearching the Web" not in rendered
 
 


### PR DESCRIPTION
## Summary
Adjust Telegram activity semantics so local lookup operations are labeled **Querying** instead of **Searching**.

## Changes
- Update `search` activity label from `🌐 Searching` to `🔎 Querying` in runtime rendering.
- Update search-related formatter tests accordingly.
- Update docs label list in `docs/index.md`.

## Why
`Searching` implies web/internet lookup. Current activity events can represent local/project queries, so `Querying` is a safer and more accurate default.

## Validation
- `uv run --only-group lint ruff check`
- `uv run ty check`
- `uv run pytest --override-ini addopts='' tests/test_telegram_bot.py -k search -q`

Closes #100
