### PR TITLE
docs(agents): require approval before self-merging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Description: A Telegram bot that implements Agent Client Protocol to interact wi
 
 - Ensure you are in a proper branch for each new feature or bugfix.
 - Never commit or push automatically unless instructed otherwise.
+- Never merge your own PRs without explicit maintainer approval in chat, even if CI is green.
 - Prefer `gh` CLI for all interactions with GitHub if possible. Eg. Use it to open PRs / manage issues.
 - For `gh pr` interactions, prefer `--body-file` with a temporary file created in the system temp directory (for example via `mktemp` or `$TMPDIR`), and delete the file after the command completes.
 - For issue categorization, use GitHub labels instead of title prefixes like `Bug:`, `Feat:`, or `Docs:`.


### PR DESCRIPTION
## Summary
Add explicit Git/GitHub guidance in `AGENTS.md`:
- do not self-merge PRs without explicit maintainer approval in chat, even when CI is green.
