### PR TITLE
fix(telegram): sanitize markdown markers in fallback messages

### DIFF
--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -1251,7 +1251,7 @@ class TelegramBridge:
                 else:
                     await message.reply_text(chunk_text)
         except (RuntimeError, ValueError, TypeError):
-            await message.reply_text(text)
+            await message.reply_text(TelegramBridge._sanitize_markdown_fallback(text))
 
     @staticmethod
     async def _send_markdown_to_chat(
@@ -1288,7 +1288,28 @@ class TelegramBridge:
                         reply_markup=current_reply_markup,
                     )
         except (RuntimeError, ValueError, TypeError):
-            await bot.send_message(chat_id=chat_id, text=text, reply_markup=reply_markup)
+            await bot.send_message(
+                chat_id=chat_id,
+                text=TelegramBridge._sanitize_markdown_fallback(text),
+                reply_markup=reply_markup,
+            )
+
+    @staticmethod
+    def _sanitize_markdown_fallback(text: str) -> str:
+        """Return plain text when markdown conversion fails."""
+        sanitized = text
+        replacements = (
+            (r"\*\*(.+?)\*\*", r"\1"),
+            (r"__(.+?)__", r"\1"),
+            (r"~~(.+?)~~", r"\1"),
+            (r"`([^`]+)`", r"\1"),
+            (r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"\1"),
+            (r"(?<!_)_([^_\n]+)_(?!_)", r"\1"),
+        )
+        for pattern, replacement in replacements:
+            sanitized = re.sub(pattern, replacement, sanitized, flags=re.DOTALL)
+        sanitized = sanitized.replace("\\\\", "\\")
+        return re.sub(r"\\([^\w])", r"\1", sanitized)
 
     def _activity_workspace(self, *, chat_id: int) -> Path:
         return self._agent_service.get_workspace(chat_id=chat_id) or self._config.default_workspace

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -2338,7 +2338,7 @@ async def test_reply_agent_falls_back_to_plain_text_on_convert_error(
     await TelegramBridge._reply_agent(update, "*x*")
 
     assert update.message.reply_kwargs[-1] == {}
-    assert update.message.replies[-1] == "*x*"
+    assert update.message.replies[-1] == "x"
 
 
 async def test_reply_falls_back_to_plain_when_entity_send_fails():
@@ -2367,7 +2367,7 @@ async def test_reply_agent_falls_back_to_plain_when_convert_fails(
     await TelegramBridge._reply_agent(update, "*x*")
 
     assert update.message.reply_kwargs[-1] == {}
-    assert update.message.replies[-1] == "*x*"
+    assert update.message.replies[-1] == "x"
 
 
 async def test_send_markdown_to_chat_falls_back_to_plain_when_entity_send_fails():
@@ -2417,8 +2417,24 @@ async def test_send_markdown_to_chat_falls_back_to_plain_when_convert_fails(monk
 
     assert len(dummy_bot.sent_messages) == 1
     payload = dummy_bot.sent_messages[0]
-    assert payload["text"] == "*bold*"
+    assert payload["text"] == "bold"
     assert payload["reply_markup"] is not None
+
+
+async def test_reply_activity_block_sanitizes_markdown_markers_when_convert_fails(monkeypatch: pytest.MonkeyPatch):
+    update = make_update()
+    assert update.message is not None
+    block = AgentActivityBlock(kind="think", title="", status="in_progress", text="Issue **#90** selected")
+
+    def boom(_: str):
+        raise RuntimeError
+
+    monkeypatch.setattr(bot_module, "convert", boom)
+
+    await TelegramBridge._reply_activity_block(update, block)
+
+    assert update.message.reply_kwargs[-1] == {}
+    assert update.message.replies[-1] == "💡 Thinking\n\nIssue #90 selected"
 
 
 async def test_on_text_ignores_when_message_is_missing():


### PR DESCRIPTION
## Summary
Fix markdown fallback rendering so activity/progress messages do not show raw markdown markers when conversion fails.

## Problem
When markdown conversion fails in Telegram rendering paths, we were sending the original text verbatim. This can expose markers like `**#90**` to end users.

## Changes
- Add `_sanitize_markdown_fallback()` in `TelegramBridge`.
- On markdown conversion fallback (`_reply_markdown_message`, `_send_markdown_to_chat`), send sanitized plain text instead of raw markdown.
- Handle common markers (`**`, `*`, `__`, `_`, `` ` ``, `~~`) and escaped punctuation artifacts.
- Add test coverage for:
  - reply fallback on convert errors,
  - send-to-chat fallback on convert errors,
  - activity block case reproducing `**#90**` behavior.

## Validation
- `uv run --only-group lint ruff check`
- `uv run ty check`
- `uv run pytest --override-ini addopts='' tests/test_telegram_bot.py -k "convert or activity_block_sanitizes_markdown" -q`

Closes #102
