### PR TITLE
fix(telegram): show Send now reliably for fast follow-up prompts

### DIFF
--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -180,6 +180,7 @@ class TelegramBridge:
         self._pending_resume_choices_by_chat: dict[int, tuple[ResumableSession, ...]] = {}
         self._chat_prompt_locks: dict[int, asyncio.Lock] = {}
         self._pending_prompts_by_chat: dict[int, _PendingPrompt] = {}
+        self._active_prompt_chats: set[int] = set()
         if hasattr(self._agent_service, "set_permission_request_handler"):
             self._agent_service.set_permission_request_handler(self.on_permission_request)
         if hasattr(self._agent_service, "set_activity_event_handler"):
@@ -606,35 +607,38 @@ class TelegramBridge:
             return
 
         chat_id = prompt_input.chat_id
-        lock = self._chat_prompt_lock(chat_id)
-
-        if lock.locked():
+        if chat_id in self._active_prompt_chats:
             await self._queue_busy_prompt(chat_id=chat_id, prompt_input=prompt_input, update=update)
             return
 
-        async with lock:
-            current_input: _PromptInput = prompt_input
-            current_update: Update = update
+        self._active_prompt_chats.add(chat_id)
+        lock = self._chat_prompt_lock(chat_id)
+        try:
+            async with lock:
+                current_input: _PromptInput = prompt_input
+                current_update: Update = update
 
-            while True:
-                reply = await self._request_reply(
-                    update=current_update,
-                    context=context,
-                    prompt_input=current_input,
-                )
+                while True:
+                    reply = await self._request_reply(
+                        update=current_update,
+                        context=context,
+                        prompt_input=current_input,
+                    )
 
-                # Pop any pending prompt before sending the reply.  Because asyncio
-                # is single-threaded, this pop and the reply dispatch below happen
-                # without yielding, so a concurrent on_message cannot sneak in between.
-                pending = self._pending_prompts_by_chat.pop(chat_id, None)
-                await self._clear_busy_button(pending)
-                await self._dispatch_reply(update=current_update, chat_id=chat_id, reply=reply)
+                    # Pop any pending prompt before sending the reply.  Because asyncio
+                    # is single-threaded, this pop and the reply dispatch below happen
+                    # without yielding, so a concurrent on_message cannot sneak in between.
+                    pending = self._pending_prompts_by_chat.pop(chat_id, None)
+                    await self._clear_busy_button(pending)
+                    await self._dispatch_reply(update=current_update, chat_id=chat_id, reply=reply)
 
-                if pending is None:
-                    break
+                    if pending is None:
+                        break
 
-                current_input = pending.prompt_input
-                current_update = pending.update
+                    current_input = pending.prompt_input
+                    current_update = pending.update
+        finally:
+            self._active_prompt_chats.discard(chat_id)
 
     async def _start_implicit_session(self, *, update: Update, chat_id: int) -> bool:
         workspace = self._config.default_workspace

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -2619,6 +2619,32 @@ async def test_on_message_while_busy_shows_send_now_button():
     await task_one
 
 
+async def test_on_message_busy_detection_uses_active_chat_marker():
+    service = BlockingService()
+    config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")
+    bridge = TelegramBridge(config=config, agent_service=cast(AgentService, service))
+    bot = DummyBot()
+    bridge._app = cast(Application, SimpleNamespace(bot=bot))
+    bridge._active_prompt_chats.add(TEST_CHAT_ID)
+
+    update = make_update(chat_id=TEST_CHAT_ID, text="queued")
+    context = make_context(application=SimpleNamespace(bot=bot))
+
+    await bridge.on_message(update, context)
+
+    assert len(bot.sent_messages) == 1
+    busy_msg = bot.sent_messages[0]
+    assert busy_msg["chat_id"] == TEST_CHAT_ID
+    assert "queued" in cast(str, busy_msg["text"]).lower()
+    markup = cast(InlineKeyboardMarkup, busy_msg["reply_markup"])
+    assert markup is not None
+    button = markup.inline_keyboard[0][0]
+    assert button.text == "Send now"
+    assert button.callback_data is not None
+    callback_data = cast(str, button.callback_data)
+    assert callback_data.startswith(f"{BUSY_CALLBACK_PREFIX}|")
+
+
 async def test_on_message_queued_runs_automatically_and_button_is_removed():
     service = BlockingService()
     config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")


### PR DESCRIPTION
## Summary
Fix a race condition in busy-state detection where very fast follow-up user messages could bypass the queue notification and not show the **Send now** button.

## Root cause
`on_message` previously checked `lock.locked()` before entering `async with lock`. Two concurrent updates could both observe the lock as unlocked before one actually acquired it, causing the second message to wait silently instead of being queued with explicit busy UX.

## Fix
- Add `TelegramBridge._active_prompt_chats` marker set.
- Mark chat as active before entering prompt-processing lock.
- Route any new message for an active chat directly through `_queue_busy_prompt(...)`.
- Clear marker in `finally` to guarantee cleanup.

## Tests
- Added `test_on_message_busy_detection_uses_active_chat_marker` to validate busy queue/button behavior based on active marker.
- Existing busy-state tests continue to pass.

## Validation
- `uv run --only-group lint ruff check`
- `uv run ty check`
- `uv run pytest --override-ini addopts='' tests/test_telegram_bot.py -k busy -q`
