### PR TITLE
fix(telegram): close busy-state race in #92 follow-up

### DIFF
--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -177,6 +177,7 @@ class TelegramBridge:
         self._pending_resume_choices_by_chat: dict[int, tuple[ResumableSession, ...]] = {}
         self._chat_prompt_locks: dict[int, asyncio.Lock] = {}
         self._pending_prompts_by_chat: dict[int, _PendingPrompt] = {}
+        self._active_prompt_chats: set[int] = set()
         if hasattr(self._agent_service, "set_permission_request_handler"):
             self._agent_service.set_permission_request_handler(self.on_permission_request)
         if hasattr(self._agent_service, "set_activity_event_handler"):
@@ -607,43 +608,45 @@ class TelegramBridge:
             return
 
         chat_id = prompt_input.chat_id
-        lock = self._chat_prompt_lock(chat_id)
-
-        if lock.locked():
+        if chat_id in self._active_prompt_chats:
             await self._queue_busy_prompt(chat_id=chat_id, prompt_input=prompt_input, update=update)
             return
 
-        async with lock:
-            current_input: _PromptInput = prompt_input
-            current_update: Update = update
+        self._active_prompt_chats.add(chat_id)
+        lock = self._chat_prompt_lock(chat_id)
+        try:
+            async with lock:
+                current_input: _PromptInput = prompt_input
+                current_update: Update = update
 
-            while True:
-                reply = await self._request_reply(
-                    update=current_update,
-                    context=context,
-                    prompt_input=current_input,
-                )
+                while True:
+                    reply = await self._request_reply(
+                        update=current_update,
+                        context=context,
+                        prompt_input=current_input,
+                    )
 
-                # Pop any pending prompt before sending the reply.  Because asyncio
-                # is single-threaded, this pop and the reply dispatch below happen
-                # without yielding, so a concurrent on_message cannot sneak in between.
-                pending = self._pending_prompts_by_chat.pop(chat_id, None)
-                await self._clear_busy_button(pending)
+                    # Pop any pending prompt before sending the reply.  Because asyncio
+                    # is single-threaded, this pop and the reply dispatch below happen
+                    # without yielding, so a concurrent on_message cannot sneak in between.
+                    pending = self._pending_prompts_by_chat.pop(chat_id, None)
+                    await self._clear_busy_button(pending)
+                    if reply is not None:
+                        if self._app is None:
+                            workspace = self._activity_workspace(chat_id=chat_id)
+                            for block in reply.activity_blocks:
+                                await self._reply_activity_block(current_update, block, workspace=workspace)
+                        if reply.text.strip():
+                            await self._reply_agent(current_update, reply.text)
+                        await self._send_attachments(current_update, reply)
 
-                if reply is not None:
-                    if self._app is None:
-                        workspace = self._activity_workspace(chat_id=chat_id)
-                        for block in reply.activity_blocks:
-                            await self._reply_activity_block(current_update, block, workspace=workspace)
-                    if reply.text.strip():
-                        await self._reply_agent(current_update, reply.text)
-                    await self._send_attachments(current_update, reply)
+                    if pending is None:
+                        break
 
-                if pending is None:
-                    break
-
-                current_input = pending.prompt_input
-                current_update = pending.update
+                    current_input = pending.prompt_input
+                    current_update = pending.update
+        finally:
+            self._active_prompt_chats.discard(chat_id)
 
     async def _start_implicit_session(self, *, update: Update, chat_id: int) -> bool:
         workspace = self._config.default_workspace

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -2430,6 +2430,32 @@ async def test_on_message_while_busy_shows_send_now_button():
     await task_one
 
 
+async def test_on_message_busy_detection_uses_active_chat_marker():
+    service = BlockingService()
+    config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")
+    bridge = TelegramBridge(config=config, agent_service=cast(AgentService, service))
+    bot = DummyBot()
+    bridge._app = cast(Application, SimpleNamespace(bot=bot))
+    bridge._active_prompt_chats.add(TEST_CHAT_ID)
+
+    update = make_update(chat_id=TEST_CHAT_ID, text="queued")
+    context = make_context(application=SimpleNamespace(bot=bot))
+
+    await bridge.on_message(update, context)
+
+    assert len(bot.sent_messages) == 1
+    busy_msg = bot.sent_messages[0]
+    assert busy_msg["chat_id"] == TEST_CHAT_ID
+    assert "queued" in cast(str, busy_msg["text"]).lower()
+    markup = cast(InlineKeyboardMarkup, busy_msg["reply_markup"])
+    assert markup is not None
+    button = markup.inline_keyboard[0][0]
+    assert button.text == "Send now"
+    assert button.callback_data is not None
+    callback_data = cast(str, button.callback_data)
+    assert callback_data.startswith(f"{BUSY_CALLBACK_PREFIX}|")
+
+
 async def test_on_message_queued_runs_automatically_and_button_is_removed():
     service = BlockingService()
     config = make_config(token="TOKEN", allowed_user_ids=[], workspace=".")


### PR DESCRIPTION
## Summary
Follow-up improvement on top of #92: fix busy-state race where very fast second messages may not show the `Send now` button.

## Context
In real Telegram use, a quick follow-up message can arrive while the first prompt is just entering execution. Depending on timing, lock-based busy detection alone can miss that window.

## Changes
- Add per-chat active marker (`_active_prompt_chats`) set before prompt processing begins.
- Route incoming messages to busy queue whenever chat is marked active.
- Cleanup marker in `finally`.
- Add regression test for active-marker busy detection path.

## Notes
This PR intentionally targets the `copilot/update-busy-state-prompt-handling` branch (PR #92), as requested.
