### PR TITLE
docs: use short uvx git URL form for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ uvx telegram-acp-bot --help
 Run the latest development version from git:
 
 ```bash
-uvx --from git+https://github.com/mgaitan/telegram-acp-bot telegram-acp-bot --help
+uvx git+https://github.com/mgaitan/telegram-acp-bot --help
 ```
 
 Run the bot with a real ACP agent:

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ uvx telegram-acp-bot --help
 Run the latest development version from git:
 
 ```bash
-uvx --from git+https://github.com/mgaitan/telegram-acp-bot telegram-acp-bot --help
+uvx git+https://github.com/mgaitan/telegram-acp-bot --help
 ```
 
 ```{richterm} env PYTHONPATH=../src uv run -m telegram_acp_bot --help


### PR DESCRIPTION
## Summary
- replace `uvx --from git+https://github.com/mgaitan/telegram-acp-bot telegram-acp-bot` with the short form `uvx git+https://github.com/mgaitan/telegram-acp-bot`
- update README and docs landing quickstart accordingly

## Validation
- `uv run ruff check README.md docs/index.md`
- `make docs`
