### PR TITLE
Use neutral querying label for non-web searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Message flow:
   - `normal`: separate activity messages, no streaming edits.
   - `compact`: one in-progress status message that becomes the final answer.
   - `verbose`: append-only in-place streaming for active reply text and tool activity.
-- Common labels are `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, `🔎 Querying project`, and fallback `🔎 Querying`.
+- Common labels are `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, and `🔎 Querying`.
 - Permission prompts for risky actions are sent as independent messages with inline buttons.
 - In `normal`, the final answer is sent as a separate message after activity blocks.
 - If the final text is empty, no dummy "(no text response)" message is sent.

--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
-import re
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -87,7 +86,6 @@ KIND_LABELS = {
     "write": "✍️ Writing",
 }
 SEARCH_LABEL_WEB = "🌐 Searching web"
-SEARCH_LABEL_LOCAL = "🔎 Querying project"
 SEARCH_LABEL_NEUTRAL = "🔎 Querying"
 REPLY_LABEL = "✍️ Replying"
 ACTIVITY_MODE_CHOICES: tuple[ActivityMode, ...] = ("normal", "compact", "verbose")
@@ -1668,11 +1666,8 @@ class TelegramBridge:
             return REPLY_LABEL
         if block.kind != "search":
             return KIND_LABELS.get(block.kind, "⚙️ Tool call")
-        source = TelegramBridge._search_source(block)
-        if source == "web":
+        if TelegramBridge._search_source(block) == "web":
             return SEARCH_LABEL_WEB
-        if source == "local":
-            return SEARCH_LABEL_LOCAL
         return SEARCH_LABEL_NEUTRAL
 
     @staticmethod
@@ -1680,20 +1675,6 @@ class TelegramBridge:
         content = f"{block.title}\n{block.text}".lower()
         if any(token in content for token in ("http://", "https://", "url:", "web search", "internet")):
             return "web"
-        if "file://" in content:
-            return "local"
-        local_patterns = (
-            r"\bworkspace\b",
-            r"\brepository\b",
-            r"\brepo\b",
-            r"\bproject\b",
-            r"\bripgrep\b",
-            r"\brg\b",
-            r"\bgrep\b",
-            r"\bglob\b",
-        )
-        if any(re.search(pattern, content) for pattern in local_patterns):
-            return "local"
         return None
 
     @staticmethod

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1814,7 +1814,7 @@ async def test_format_activity_block_search_uses_web_label_when_url_present():
     assert "*🌐 Searching web*" in rendered
 
 
-async def test_format_activity_block_search_uses_project_label_for_local_markers():
+async def test_format_activity_block_search_uses_neutral_label_for_local_markers():
     block = AgentActivityBlock(
         kind="search",
         title='Query project for "ACP_TELEGRAM_CHANNEL_ALLOW_PATH"',
@@ -1822,7 +1822,7 @@ async def test_format_activity_block_search_uses_project_label_for_local_markers
         text="ripgrep in workspace",
     )
     rendered = TelegramBridge._format_activity_block(block)
-    assert "*🔎 Querying project*" in rendered
+    assert "*🔎 Querying*" in rendered
 
 
 async def test_format_activity_block_search_defaults_to_neutral_querying_label():
@@ -1847,7 +1847,7 @@ async def test_format_activity_block_search_report_word_is_not_misclassified_as_
     assert "*🔎 Querying*" in rendered
 
 
-async def test_format_activity_block_search_uses_project_label_for_file_uri():
+async def test_format_activity_block_search_uses_neutral_label_for_file_uri():
     block = AgentActivityBlock(
         kind="search",
         title='Query: "config"',
@@ -1855,7 +1855,7 @@ async def test_format_activity_block_search_uses_project_label_for_file_uri():
         text="file:///home/user/project/pyproject.toml",
     )
     rendered = TelegramBridge._format_activity_block(block)
-    assert "*🔎 Querying project*" in rendered
+    assert "*🔎 Querying*" in rendered
 
 
 async def test_format_activity_block_reply_and_fallback_helpers():


### PR DESCRIPTION
## Summary
- remove `🔎 Querying project` search label
- keep `🌐 Searching web` for web-indicated searches
- route local/project/file-uri search cases to neutral fallback `🔎 Querying`
- update tests and docs label lists accordingly

## Testing
- uv run --group test -p 3.13 pytest
