### PR TITLE
Localize activity labels and show search query details

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Current interaction capabilities:
 
 Message flow:
 - The bot sends activity blocks while the prompt is running.
-- Common labels are `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, and `🔎 Querying`.
+- Common labels are `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, and `🔎 Querying` (or Spanish equivalents when `ACP_UI_LANGUAGE=es`).
 - Permission prompts for risky actions are sent as independent messages with inline buttons.
 - The final answer is sent as a separate message after activity blocks.
 - If the final text is empty, no dummy "(no text response)" message is sent.
@@ -80,6 +80,7 @@ ACP_RESTART_COMMAND="uv run telegram-acp-bot --telegram-token <TOKEN> --agent-co
 ACP_PERMISSION_MODE=ask
 ACP_PERMISSION_EVENT_OUTPUT=stdout
 ACP_STDIO_LIMIT=8388608
+ACP_UI_LANGUAGE=en
 ```
 
 ## Agent Command

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,11 @@ ACP_STDIO_LIMIT
   Increase this if the agent emits very large JSON lines.
   Maps to `--acp-stdio-limit`.
 
+ACP_UI_LANGUAGE
+  Language used for Telegram activity labels.
+  Allowed values: `en`, `es`.
+  Maps to `--ui-language`.
+
 ACP_CONNECT_TIMEOUT
   Timeout in seconds for ACP initialize/new_session handshake.
   Prevents `/new` from hanging forever if the agent does not speak ACP over stdio.
@@ -76,6 +81,7 @@ ACP_PERMISSION_MODE=ask
 ACP_PERMISSION_EVENT_OUTPUT=stdout
 ACP_STDIO_LIMIT=8388608
 ACP_CONNECT_TIMEOUT=30
+ACP_UI_LANGUAGE=en
 ACP_LOG_LEVEL=INFO
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ Attachment behavior:
 
 Tool activity behavior:
 - ACP tool updates are emitted as separate Telegram messages grouped by tool kind (`think`, `execute`, `read`, etc.).
-- Labels currently used in chat are: `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, and `🔎 Querying`.
+- Labels currently used in chat are: `💡 Thinking`, `⚙️ Running`, `📖 Reading`, `✏️ Editing`, `✍️ Writing`, `🌐 Searching web`, and `🔎 Querying` (or Spanish equivalents when {term}`ACP_UI_LANGUAGE` is set to `es`).
 - Search activity blocks render compact details when available (`Query: "..."` and `URL: ...`) extracted from block title/text.
 - Permission prompts for risky actions are sent as independent messages with inline buttons.
 - The final assistant answer is sent as a separate message after those activity blocks.

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -26,6 +26,7 @@ from telegram_acp_bot.telegram.bot import RESTART_EXIT_CODE, TelegramBridge, mak
 
 ALLOWED_USER_IDS_ENV = "TELEGRAM_ALLOWED_USER_IDS"
 ALLOWED_USERNAMES_ENV = "TELEGRAM_ALLOWED_USERNAMES"
+UI_LANGUAGE_ENV = "ACP_UI_LANGUAGE"
 
 
 def get_version() -> str:
@@ -91,6 +92,12 @@ def get_parser() -> argparse.ArgumentParser:
         "--restart-command",
         default=os.getenv("ACP_RESTART_COMMAND", ""),
         help="Optional command used by /restart to relaunch the bot (e.g. 'uv run telegram-acp-bot').",
+    )
+    parser.add_argument(
+        "--ui-language",
+        default=os.getenv(UI_LANGUAGE_ENV, "en"),
+        choices=["en", "es"],
+        help="Language for Telegram activity labels.",
     )
     return parser
 
@@ -166,6 +173,7 @@ def main(args: list[str] | None = None) -> int:
         allowed_user_ids=allowed_user_ids,
         allowed_usernames=allowed_usernames,
         workspace=opts.workspace,
+        ui_language=opts.ui_language,
     )
     service = AcpAgentService(
         SessionRegistry(),

--- a/src/telegram_acp_bot/acp_app/acp_service.py
+++ b/src/telegram_acp_bot/acp_app/acp_service.py
@@ -8,7 +8,7 @@ import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 from urllib.parse import unquote, urlparse
 from uuid import uuid4
 
@@ -217,9 +217,10 @@ class _AcpClient:
                 title=update.title,
             )
             if label != "think":
+                start_text = self._tool_start_text(update)
                 await self._emit_activity_block(
                     session_id=session_id,
-                    block=AgentActivityBlock(kind=label, title=update.title, status="in_progress"),
+                    block=AgentActivityBlock(kind=label, title=update.title, status="in_progress", text=start_text),
                 )
             return
         if isinstance(update, ToolCallProgress):
@@ -326,6 +327,46 @@ class _AcpClient:
         if not previous[-2].isdigit() or len(chunk) < MIN_NUMERIC_DOT_CHUNK_MIN_LENGTH:
             return False
         return chunk[1].isdigit() or chunk[1] == "."
+
+    @staticmethod
+    def _tool_start_text(update: ToolCallStart) -> str:
+        if update.kind != "search":
+            return ""
+        queries = _AcpClient._collect_search_queries(update.raw_input)
+        if not queries:
+            return ""
+        return "\n".join(f'Query: "{query}"' for query in queries)
+
+    @staticmethod
+    def _collect_search_queries(raw_input: Any) -> list[str]:
+        queries: list[str] = []
+        seen_values: set[str] = set()
+        pending: list[Any] = [raw_input]
+        seen_nodes: set[int] = set()
+        query_keys = {"q", "query"}
+
+        while pending:
+            current = pending.pop(0)
+            node_id = id(current)
+            if node_id in seen_nodes:
+                continue
+            seen_nodes.add(node_id)
+
+            if isinstance(current, dict):
+                for key, value in current.items():
+                    normalized_key = key.lower().strip()
+                    if normalized_key in query_keys and isinstance(value, str):
+                        normalized_query = value.strip()
+                        if normalized_query and normalized_query not in seen_values:
+                            queries.append(normalized_query)
+                            seen_values.add(normalized_query)
+                    if isinstance(value, dict | list | tuple):
+                        pending.append(value)
+                continue
+            if isinstance(current, list | tuple):
+                pending.extend(current)
+
+        return queries
 
     async def _open_tool_block(self, *, session_id: str, tool_call_id: str, kind: str, title: str) -> None:
         await self._close_active_tool_block(session_id=session_id, status="in_progress")

--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -57,15 +57,30 @@ RESUME_KEYBOARD_MAX_ROWS = 10
 RESTART_EXIT_CODE = 75
 TELEGRAM_MAX_UTF16_MESSAGE_LENGTH = 4096
 logger = logging.getLogger(__name__)
-KIND_LABELS = {
-    "think": "💡 Thinking",
-    "execute": "⚙️ Running",
-    "read": "📖 Reading",
-    "edit": "✏️ Editing",
-    "write": "✍️ Writing",
+UiLanguage = Literal["en", "es"]
+DEFAULT_UI_LANGUAGE: UiLanguage = "en"
+KIND_LABELS_BY_LANGUAGE: dict[UiLanguage, dict[str, str]] = {
+    "en": {
+        "think": "💡 Thinking",
+        "execute": "⚙️ Running",
+        "read": "📖 Reading",
+        "edit": "✏️ Editing",
+        "write": "✍️ Writing",
+        "fallback": "⚙️ Tool call",
+        "search_web": "🌐 Searching web",
+        "search_neutral": "🔎 Querying",
+    },
+    "es": {
+        "think": "💡 Pensando",
+        "execute": "⚙️ Ejecutando",
+        "read": "📖 Leyendo",
+        "edit": "✏️ Editando",
+        "write": "✍️ Escribiendo",
+        "fallback": "⚙️ Llamada de herramienta",
+        "search_web": "🌐 Buscando en la web",
+        "search_neutral": "🔎 Consultando",
+    },
 }
-SEARCH_LABEL_WEB = "🌐 Searching web"
-SEARCH_LABEL_NEUTRAL = "🔎 Querying"
 
 
 @dataclass(slots=True, frozen=True)
@@ -76,6 +91,7 @@ class BotConfig:
     allowed_user_ids: set[int]
     allowed_usernames: set[str]
     default_workspace: Path
+    ui_language: UiLanguage = DEFAULT_UI_LANGUAGE
 
 
 @dataclass(slots=True, frozen=True)
@@ -409,7 +425,7 @@ class TelegramBridge:
             return
 
         workspace = self._activity_workspace(chat_id=chat_id)
-        text = self._format_activity_block(block, workspace=workspace)
+        text = self._format_activity_block(block, workspace=workspace, ui_language=self._config.ui_language)
         await TelegramBridge._send_markdown_to_chat(bot=app.bot, chat_id=chat_id, text=text)
 
     async def on_permission_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1014,17 +1030,27 @@ class TelegramBridge:
 
     @staticmethod
     async def _reply_activity_block(
-        update: Update, block: AgentActivityBlock, *, workspace: Path | None = None
+        update: Update,
+        block: AgentActivityBlock,
+        *,
+        workspace: Path | None = None,
+        ui_language: UiLanguage | str = DEFAULT_UI_LANGUAGE,
     ) -> None:
         if update.message is None:
             return
 
-        text = TelegramBridge._format_activity_block(block, workspace=workspace)
+        text = TelegramBridge._format_activity_block(block, workspace=workspace, ui_language=ui_language)
         await TelegramBridge._reply_markdown_message(update.message, text=text)
 
     @staticmethod
-    def _format_activity_block(block: AgentActivityBlock, *, workspace: Path | None = None) -> str:
-        label = TelegramBridge._activity_label(block)
+    def _format_activity_block(
+        block: AgentActivityBlock,
+        *,
+        workspace: Path | None = None,
+        ui_language: UiLanguage | str = DEFAULT_UI_LANGUAGE,
+    ) -> str:
+        normalized_ui_language = TelegramBridge._normalize_ui_language(ui_language)
+        label = TelegramBridge._activity_label(block, ui_language=normalized_ui_language)
         text_parts = [f"*{label}*"]
         normalized_title = TelegramBridge._normalize_activity_title(block, workspace=workspace)
         normalized_text = TelegramBridge._normalize_activity_text(block, workspace=workspace)
@@ -1039,13 +1065,21 @@ class TelegramBridge:
         return "\n\n".join(text_parts)
 
     @staticmethod
-    def _activity_label(block: AgentActivityBlock) -> str:
+    def _activity_label(block: AgentActivityBlock, *, ui_language: UiLanguage = DEFAULT_UI_LANGUAGE) -> str:
+        labels = KIND_LABELS_BY_LANGUAGE[ui_language]
         if block.kind != "search":
-            return KIND_LABELS.get(block.kind, "⚙️ Tool call")
+            return labels.get(block.kind, labels["fallback"])
         source = TelegramBridge._search_source(block)
         if source == "web":
-            return SEARCH_LABEL_WEB
-        return SEARCH_LABEL_NEUTRAL
+            return labels["search_web"]
+        return labels["search_neutral"]
+
+    @staticmethod
+    def _normalize_ui_language(raw_language: UiLanguage | str) -> UiLanguage:
+        normalized = raw_language.strip().lower()
+        if normalized == "es":
+            return "es"
+        return DEFAULT_UI_LANGUAGE
 
     @staticmethod
     def _search_source(block: AgentActivityBlock) -> str | None:
@@ -1292,6 +1326,7 @@ def make_config(
     allowed_user_ids: list[int],
     workspace: str,
     allowed_usernames: list[str] | None = None,
+    ui_language: UiLanguage | str = DEFAULT_UI_LANGUAGE,
 ) -> BotConfig:
     normalized_usernames = {
         username.lstrip("@").strip().lower() for username in (allowed_usernames or []) if username.strip()
@@ -1301,4 +1336,5 @@ def make_config(
         allowed_user_ids=set(allowed_user_ids),
         allowed_usernames=normalized_usernames,
         default_workspace=Path(workspace).expanduser(),
+        ui_language=TelegramBridge._normalize_ui_language(ui_language),
     )

--- a/tests/test_acp_service.py
+++ b/tests/test_acp_service.py
@@ -509,6 +509,41 @@ async def test_acp_client_emits_live_activity_blocks():
     assert events[1] == AgentActivityBlock(kind="execute", title="Run command", status="in_progress", text="")
 
 
+async def test_acp_client_emits_search_query_in_live_activity_block():
+    events: list[AgentActivityBlock] = []
+
+    async def allow_first(_: str, options: list[PermissionOption], tool_call: ToolCall) -> RequestPermissionResponse:
+        del options, tool_call
+        return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+
+    async def capture_event(_: str, block: AgentActivityBlock) -> None:
+        events.append(block)
+
+    client = _AcpClient(permission_decider=allow_first, activity_reporter=capture_event)
+    session_id = "s-search-live"
+    client.start_capture(session_id)
+
+    await client.session_update(
+        session_id=session_id,
+        update=ToolCallStart(
+            title="Searching the Web",
+            tool_call_id="tool-search",
+            kind="search",
+            raw_input={"search_query": [{"q": "telegram acp bot"}]},
+            session_update="tool_call",
+        ),
+    )
+
+    assert events == [
+        AgentActivityBlock(
+            kind="search",
+            title="Searching the Web",
+            status="in_progress",
+            text='Query: "telegram acp bot"',
+        )
+    ]
+
+
 async def test_acp_client_flushes_non_tool_text_as_thinking_before_next_tool():
     events: list[AgentActivityBlock] = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,16 @@ def test_main_runs_bot(mocker):
     mock_run_polling.assert_called_once()
 
 
+def test_main_passes_ui_language_to_config(mocker):
+    """CLI forwards UI language to runtime config."""
+    mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
+
+    assert main(["--telegram-token", "TOKEN", "--agent-command", "agent", "--ui-language", "es"]) == 0
+    assert mock_run_polling.call_args is not None
+    config = mock_run_polling.call_args.args[0]
+    assert config.ui_language == "es"
+
+
 def test_main_reexecs_process_on_restart_request(mocker):
     """When polling returns restart code, main re-execs current process."""
     mocker.patch("telegram_acp_bot.run_polling", return_value=RESTART_EXIT_CODE)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1542,6 +1542,17 @@ async def test_format_activity_block_search_uses_web_label_when_url_present():
     assert "*🌐 Searching web*" in rendered
 
 
+async def test_format_activity_block_search_uses_spanish_label_when_configured():
+    block = AgentActivityBlock(
+        kind="search",
+        title='Query: "telegram acp"',
+        status="completed",
+        text="URL: https://agentclientprotocol.com/",
+    )
+    rendered = TelegramBridge._format_activity_block(block, ui_language="es")
+    assert "*🌐 Buscando en la web*" in rendered
+
+
 async def test_format_activity_block_search_uses_neutral_label_for_local_markers():
     block = AgentActivityBlock(
         kind="search",
@@ -1562,6 +1573,17 @@ async def test_format_activity_block_search_defaults_to_neutral_querying_label()
     )
     rendered = TelegramBridge._format_activity_block(block)
     assert "*🔎 Querying*" in rendered
+
+
+async def test_format_activity_block_search_uses_spanish_neutral_label_when_configured():
+    block = AgentActivityBlock(
+        kind="search",
+        title='Query: "send now"',
+        status="completed",
+        text="",
+    )
+    rendered = TelegramBridge._format_activity_block(block, ui_language="es")
+    assert "*🔎 Consultando*" in rendered
 
 
 async def test_format_activity_block_search_report_word_is_not_misclassified_as_repo():


### PR DESCRIPTION
## Summary
- add UI language selection for Telegram activity labels via ACP_UI_LANGUAGE / --ui-language (en|es)
- localize search and tool-call labels in the Telegram bridge
- include extracted search query text in live search activity blocks when ACP provides raw_input
- update docs and tests for new behavior

## Testing
- uv run ty check
- uv run pytest --no-cov tests/test_cli.py tests/test_telegram_bot.py
- uv run pytest --no-cov tests/test_acp_service.py -k "emits_live_activity_blocks or emits_search_query_in_live_activity_block"
