### PR TITLE
ci: auto-publish docs on main pushes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,14 @@
 name: Publish to PyPI
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - ".github/workflows/cd.yml"
   release:
     types: [created]
   pull_request:
@@ -35,7 +43,7 @@ jobs:
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'release' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     environment:
       name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}


### PR DESCRIPTION
## Summary
- trigger docs publication on `push` to `main` when docs-related files change
- prevent docs deployment during `release` events

## Why
Merges to `main` were not automatically updating production docs. This made docs look stale/broken unless manually redeployed.

## Validation
- manually triggered `cd.yml` and verified `docs-publish` completed successfully
