### PR TITLE
Fix queued busy notifications across activity modes

### DIFF
--- a/src/telegram_acp_bot/telegram/bot.py
+++ b/src/telegram_acp_bot/telegram/bot.py
@@ -1187,9 +1187,6 @@ class TelegramBridge:
             finally:
                 self._dequeued_prompts_by_chat.pop(chat_id, None)
 
-            if pending is None:
-                return
-
             with bind_log_context(chat_id=chat_id, prompt_cycle_id=pending.prompt_input.cycle_id):
                 logger.info("Dequeued pending prompt cycle")
             current_input = pending.prompt_input

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -3746,6 +3746,31 @@ async def test_update_busy_notification_query_fallback_clears_reply_markup():
     assert callback.edited_kwargs["reply_markup"] is None
 
 
+async def test_update_busy_notification_falls_back_to_dismiss_when_query_edit_fails():
+    bridge = make_bridge()
+
+    class FailingBusyCallbackQuery(DummyCallbackQuery):
+        async def edit_message_text(self, text: str, **kwargs: object) -> None:
+            del text, kwargs
+            raise MarkdownFailureError
+
+    pending = _PendingPrompt(
+        prompt_input=_PromptInput(chat_id=TEST_CHAT_ID, text="queued", images=(), files=()),
+        update=cast(Update, make_update(chat_id=TEST_CHAT_ID, text="queued")),
+        token="queued-token",
+    )
+    callback = FailingBusyCallbackQuery(f"{BUSY_CALLBACK_PREFIX}|queued-token")
+
+    await bridge._update_busy_notification(
+        chat_id=TEST_CHAT_ID,
+        pending=pending,
+        query=cast(CallbackQuery, callback),
+        text=BUSY_SENT_TEXT,
+    )
+
+    assert callback.reply_markup_cleared
+
+
 @pytest.mark.parametrize("mode", ["normal", "compact", "verbose"])
 async def test_on_busy_callback_updates_stored_notification_when_query_edit_fails(mode: str):
     service = BlockingActivityService()


### PR DESCRIPTION
## Summary

Fix busy queue notifications so they behave consistently across all activity modes.

## What changed

- show the queued notification reliably in `normal`, `compact`, and `verbose`
- make `Send now` update the stored busy notification even when the callback query message cannot be edited directly
- keep the button visible until the queued prompt is actually dequeued
- handle the small race where a queued prompt is already dequeued but the user can still click the button
- refresh auto-dequeued notifications to `✅ Sent.` instead of leaving stale `queued` text behind
- unify the final busy-notification copy to `✅ Sent.` for both manual and automatic dequeue paths

## Validation

- `uv run pytest --no-cov tests/test_telegram_bot.py -q`
- `uv run --only-group lint ruff check src/telegram_acp_bot/telegram/bot.py tests/test_telegram_bot.py`
- `uv run ty check src`
