### PR TITLE
ci: upgrade actions/checkout to v5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
@@ -65,7 +65,7 @@ jobs:
       name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/configure-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   workflows-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Lint GitHub workflows
         uses: rhysd/actionlint@v1.7.9
 
@@ -20,7 +20,7 @@ jobs:
     needs: workflows-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
 
       - name: Ruff check
@@ -41,7 +41,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
       - name: Run tests with coverage
         run: uv run --group test -p ${{ matrix.python-version }} pytest

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -13,7 +13,7 @@ jobs:
   update-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
 
       - name: Capture template version (before)


### PR DESCRIPTION
## Summary
- upgrade all workflow uses of `actions/checkout` from `v4` to `v5`
- keep the workflow behavior unchanged while removing the Node 20 deprecation warning source
- update CI, release/docs, and template refresh workflows together for consistency

## Validation
- parsed the updated workflow YAML files successfully
- verified all `actions/checkout` references now point to `@v5`

## Notes
- Based on the official `actions/checkout` `v5.0.0` release
