### PR TITLE
Exclude local worktrees from ty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ __pycache__/
 .env
 .env.*
 !.env.example
+
+# local worktrees and generated artifacts
+.worktrees/
+.external-worktrees/
+artifacts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ module-name = "telegram_acp_bot"
 exclude-newer = "1 week"
 exclude-newer-package = { ty = "0 days" }
 
+[tool.ty.src]
+exclude = [".worktrees/", ".external-worktrees/", "artifacts/"]
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
## Summary
Exclude local worktree directories from Git noise and from `ty` file discovery.

This avoids type-checking unrelated local worktrees under `.worktrees/` and `.external-worktrees/`, and ignores the local `artifacts/` directory used in this repository.

## Testing
- `uv run ty check`
