### PR TITLE
Document release Makefile targets for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Description: A Telegram bot that implements Agent Client Protocol to interact wi
   For common AI collaborators, use:
   - "Co-authored-by: Codex <codex@openai.com>".
   - "Co-authored-by: Claude <noreply@anthropic.com>".
-- For releases, prefer the repository `Makefile` targets instead of ad-hoc commands. Use `make release-check` to run the release validation steps, and `make release` to publish a release. When preparing a version-bump PR, use `make bump` (which currently bumps the minor version only).
+- For releases, prefer the repository `Makefile` targets instead of ad-hoc commands. Use `make release` to run checks and publish a release. When preparing a version-bump PR, use `make bump` (which currently bumps the minor version only).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
Document that agents should use the repository release targets from `Makefile` instead of ad-hoc release commands.

## Testing
- not run (documentation-only change)
