### PR TITLE
feat: add voice message transcription support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "agent-client-protocol>=0.8.1",
     "aiolimiter>=1.2.1",
+    "httpx>=0.25.0",
     "mcp>=1.26.0",
     "python-dotenv>=1.2.1",
     "python-telegram-bot>=22.6",

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -18,6 +18,12 @@ from typing import cast
 from acp.schema import EnvVariable, McpServerStdio
 from dotenv import load_dotenv
 
+# Load environment variables from .env file in current directory
+import os
+env_path = os.path.join(os.getcwd(), '.env')
+if os.path.exists(env_path):
+    load_dotenv(env_path)
+
 from telegram_acp_bot.acp.models import ActivityMode, PermissionEventOutput, PermissionMode
 from telegram_acp_bot.acp.service import AcpAgentService
 from telegram_acp_bot.core.session_registry import SessionRegistry

--- a/src/telegram_acp_bot/acp/client.py
+++ b/src/telegram_acp_bot/acp/client.py
@@ -16,7 +16,7 @@ from acp.schema import (
     EmbeddedResourceContentBlock,
     EnvVariable,
     ImageContentBlock,
-    KillTerminalCommandResponse,
+    KillTerminalResponse,
     PermissionOption,
     ReadTextFileResponse,
     ReleaseTerminalResponse,
@@ -402,7 +402,7 @@ class _AcpClient:
 
     async def kill_terminal(
         self, session_id: str, terminal_id: str, **kwargs: object
-    ) -> KillTerminalCommandResponse | None:
+    ) -> KillTerminalResponse | None:
         del session_id, terminal_id, kwargs
         raise RequestError.method_not_found("terminal/kill")
 

--- a/src/telegram_acp_bot/audio_transcriber/__init__.py
+++ b/src/telegram_acp_bot/audio_transcriber/__init__.py
@@ -1,0 +1,71 @@
+"""
+Audio Transcriber Module for Telegram ACP Bot
+
+This module provides audio transcription capabilities for the Telegram ACP Bot.
+It supports multiple transcription providers with a unified interface.
+
+Quick Start:
+    from audio_transcriber import (
+        initialize_transcriber,
+        transcribe_audio,
+        close_transcriber
+    )
+    
+    # Initialize
+    await initialize_transcriber()
+    
+    # Transcribe
+    text = await transcribe_audio(audio_bytes)
+    
+    # Cleanup
+    await close_transcriber()
+
+Configuration:
+    Set environment variables:
+    - AUDIO_TRANSCRIPTION_ENABLED=true
+    - AUDIO_TRANSCRIPTION_PROVIDER=groq
+    - GROQ_API_KEY=your-api-key
+    - WHISPER_MODEL=whisper-large-v3
+    - TRANSCRIPTION_LANGUAGE=it
+
+Providers:
+    - groq: Groq Whisper API (whisper-large-v3, whisper-large-v3-turbo)
+    - openai: OpenAI Whisper API (future)
+"""
+
+from .config import TranscriberConfig, get_config, reload_config
+from .transcriber import (
+    AudioTranscriber,
+    get_transcriber,
+    initialize_transcriber,
+    transcribe_audio,
+    close_transcriber,
+)
+from .providers.base import BaseTranscriber, TranscriptionError
+from .providers.groq import GroqTranscriber
+
+__version__ = "1.0.0"
+__author__ = "Telegram ACP Bot Audio Extension"
+
+__all__ = [
+    # Main functions
+    "initialize_transcriber",
+    "transcribe_audio",
+    "close_transcriber",
+    "get_transcriber",
+    
+    # Configuration
+    "get_config",
+    "reload_config",
+    "TranscriberConfig",
+    
+    # Provider classes
+    "BaseTranscriber",
+    "GroqTranscriber",
+    
+    # Exceptions
+    "TranscriptionError",
+    
+    # Main class
+    "AudioTranscriber",
+]

--- a/src/telegram_acp_bot/audio_transcriber/config.py
+++ b/src/telegram_acp_bot/audio_transcriber/config.py
@@ -1,0 +1,177 @@
+"""
+Audio Transcriber Configuration Module
+
+Handles loading and validating configuration from environment variables.
+Supports multiple providers and fallback configurations.
+"""
+
+import os
+import logging
+from typing import Optional, Dict, Any
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriberConfig:
+    """Configuration for the audio transcriber."""
+    
+    # Enable/disable transcription
+    enabled: bool = True
+    
+    # Provider selection ("groq", "openai", etc.)
+    provider: str = "groq"
+    
+    # API keys for different providers
+    groq_api_key: Optional[str] = None
+    openai_api_key: Optional[str] = None
+    
+    # Model configuration
+    whisper_model: str = "whisper-large-v3"
+    
+    # Transcription settings
+    language: str = "it"  # Default to Italian
+    timeout: int = 60  # Seconds
+    retries: int = 3
+    
+    # File limits
+    max_file_size_mb: int = 25
+    
+    # Debug mode
+    debug: bool = False
+    
+    # Fallback settings
+    fallback_enabled: bool = False
+    fallback_provider: Optional[str] = None
+    
+    @classmethod
+    def from_env(cls, env_file: Optional[str] = None) -> "TranscriberConfig":
+        """
+        Load configuration from environment variables.
+        
+        Args:
+            env_file: Optional path to .env file (not used, relies on os.environ)
+        
+        Returns:
+            TranscriberConfig instance
+        """
+        # Helper to get boolean from env
+        def get_bool(name: str, default: bool) -> bool:
+            value = os.getenv(name, str(default)).lower()
+            return value in ("true", "1", "yes", "on")
+        
+        # Helper to get optional string
+        def get_opt_str(name: str) -> Optional[str]:
+            value = os.getenv(name, "").strip()
+            return value if value else None
+        
+        config = cls(
+            enabled=get_bool("AUDIO_TRANSCRIPTION_ENABLED", True),
+            provider=os.getenv("AUDIO_TRANSCRIPTION_PROVIDER", "groq").lower(),
+            groq_api_key=get_opt_str("GROQ_API_KEY"),
+            openai_api_key=get_opt_str("OPENAI_API_KEY"),
+            whisper_model=os.getenv("WHISPER_MODEL", "whisper-large-v3"),
+            language=os.getenv("TRANSCRIPTION_LANGUAGE", "it"),
+            timeout=int(os.getenv("TRANSCRIPTION_TIMEOUT", "60")),
+            retries=int(os.getenv("TRANSCRIPTION_RETRIES", "3")),
+            max_file_size_mb=int(os.getenv("AUDIO_MAX_FILE_SIZE_MB", "25")),
+            debug=get_bool("AUDIO_TRANSCRIPTION_DEBUG", False),
+            fallback_enabled=get_bool("AUDIO_FALLBACK_ENABLED", False),
+            fallback_provider=get_opt_str("AUDIO_FALLBACK_PROVIDER"),
+        )
+        
+        # Validate configuration
+        config._validate()
+        
+        return config
+    
+    def _validate(self):
+        """Validate the configuration."""
+        # Check API key for selected provider
+        if self.enabled:
+            if self.provider == "groq" and not self.groq_api_key:
+                logger.warning(
+                    "Audio transcription enabled but GROQ_API_KEY not set. "
+                    "Transcription will fail."
+                )
+            elif self.provider == "openai" and not self.openai_api_key:
+                logger.warning(
+                    "Audio transcription enabled but OPENAI_API_KEY not set. "
+                    "Transcription will fail."
+                )
+        
+        # Validate provider
+        valid_providers = ["groq", "openai"]
+        if self.provider not in valid_providers:
+            logger.warning(
+                f"Unknown provider '{self.provider}'. Using 'groq' as default."
+            )
+            self.provider = "groq"
+        
+        # Validate model
+        valid_models = ["whisper-large-v3", "whisper-large-v3-turbo"]
+        if self.whisper_model not in valid_models:
+            logger.warning(
+                f"Unknown model '{self.whisper_model}'. "
+                f"Valid models: {valid_models}"
+            )
+        
+        # Validate language code
+        if len(self.language) != 2:
+            logger.warning(
+                f"Language code '{self.language}' may be invalid. "
+                "Expected 2-letter ISO code (e.g., 'it', 'en')."
+            )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert configuration to dictionary (without sensitive data)."""
+        return {
+            "enabled": self.enabled,
+            "provider": self.provider,
+            "whisper_model": self.whisper_model,
+            "language": self.language,
+            "timeout": self.timeout,
+            "retries": self.retries,
+            "max_file_size_mb": self.max_file_size_mb,
+            "debug": self.debug,
+            "fallback_enabled": self.fallback_enabled,
+            "fallback_provider": self.fallback_provider,
+            # Note: API keys are NOT included for security
+        }
+    
+    def __str__(self) -> str:
+        return (
+            f"TranscriberConfig(provider={self.provider}, "
+            f"model={self.whisper_model}, language={self.language})"
+        )
+
+
+# Global configuration instance (lazy loaded)
+_config: Optional[TranscriberConfig] = None
+
+
+def get_config() -> TranscriberConfig:
+    """
+    Get the global configuration instance.
+    
+    Returns:
+        TranscriberConfig instance
+    """
+    global _config
+    if _config is None:
+        _config = TranscriberConfig.from_env()
+    return _config
+
+
+def reload_config() -> TranscriberConfig:
+    """
+    Reload configuration from environment variables.
+    
+    Returns:
+        New TranscriberConfig instance
+    """
+    global _config
+    _config = TranscriberConfig.from_env()
+    logger.info("Configuration reloaded")
+    return _config

--- a/src/telegram_acp_bot/audio_transcriber/providers/base.py
+++ b/src/telegram_acp_bot/audio_transcriber/providers/base.py
@@ -1,0 +1,105 @@
+"""
+Base Transcriber Module
+
+Abstract base class for all transcription providers.
+All providers must inherit from this class and implement the transcribe method.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TranscriptionError(Exception):
+    """Exception raised when transcription fails."""
+    
+    def __init__(self, message: str, provider: Optional[str] = None):
+        self.message = message
+        self.provider = provider
+        super().__init__(self.message)
+
+
+class BaseTranscriber(ABC):
+    """
+    Abstract base class for audio transcription providers.
+    
+    This class defines the interface that all transcription providers must implement.
+    To add a new provider, inherit from this class and implement the transcribe method.
+    
+    Example:
+        class MyProviderTranscriber(BaseTranscriber):
+            async def transcribe(self, audio_data: bytes, language: str = "it") -> str:
+                # Implementation here
+                pass
+    """
+    
+    def __init__(self, api_key: str, model: str, **kwargs):
+        """
+        Initialize the transcriber.
+        
+        Args:
+            api_key: API key for the transcription service
+            model: Model name to use for transcription
+            **kwargs: Additional provider-specific configuration
+        """
+        self.api_key = api_key
+        self.model = model
+        self.config = kwargs
+        self._initialized = False
+    
+    @abstractmethod
+    async def transcribe(self, audio_data: bytes, language: str = "it") -> str:
+        """
+        Transcribe audio data to text.
+        
+        Args:
+            audio_data: Raw audio file bytes (max 25MB)
+            language: Language code for transcription (default: "it" for Italian)
+        
+        Returns:
+            Transcribed text as string
+        
+        Raises:
+            TranscriptionError: If transcription fails
+        """
+        pass
+    
+    async def initialize(self) -> bool:
+        """
+        Initialize the transcriber (optional, can be overridden by providers).
+        
+        Returns:
+            True if initialization successful, False otherwise
+        """
+        self._initialized = True
+        return True
+    
+    async def close(self):
+        """
+        Close any open connections (optional, can be overridden by providers).
+        """
+        self._initialized = False
+    
+    def is_available(self) -> bool:
+        """
+        Check if the transcriber is available and ready to use.
+        
+        Returns:
+            True if available, False otherwise
+        """
+        return self._initialized
+    
+    @property
+    def provider_name(self) -> str:
+        """
+        Return the name of the provider.
+        
+        Returns:
+            Provider name (e.g., "groq", "openai", "azure")
+        """
+        return self.__class__.__name__.replace("Transcriber", "").lower()
+    
+    def __str__(self) -> str:
+        return f"{self.provider_name} transcriber ({self.model})"

--- a/src/telegram_acp_bot/audio_transcriber/providers/groq.py
+++ b/src/telegram_acp_bot/audio_transcriber/providers/groq.py
@@ -1,0 +1,222 @@
+"""
+Groq Whisper Transcriber Module
+
+Implementation of the BaseTranscriber for Groq's Whisper API.
+Supports whisper-large-v3 and whisper-large-v3-turbo models.
+"""
+
+import asyncio
+import httpx
+import logging
+from typing import Optional
+from .base import BaseTranscriber, TranscriptionError
+
+logger = logging.getLogger(__name__)
+
+# Groq API endpoint for Whisper
+GROQ_WHISPER_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
+
+# Supported models
+GROQ_WHISPER_MODELS = {
+    "whisper-large-v3": {
+        "description": "OpenAI Whisper Large v3 - Maximum accuracy",
+        "max_file_size_mb": 25,
+        "supported_languages": "99+ languages including Italian",
+    },
+    "whisper-large-v3-turbo": {
+        "description": "OpenAI Whisper Large v3 Turbo - Faster, slightly less accurate",
+        "max_file_size_mb": 25,
+        "supported_languages": "99+ languages including Italian",
+    },
+}
+
+# Rate limits (from Groq documentation)
+GROQ_RATE_LIMITS = {
+    "requests_per_minute": 30,
+    "requests_per_day": 14400,
+    "max_file_size_mb": 25,
+}
+
+
+class GroqTranscriber(BaseTranscriber):
+    """
+    Groq Whisper transcription provider.
+    
+    Uses Groq's API to transcribe audio using OpenAI's Whisper models.
+    Supports both whisper-large-v3 and whisper-large-v3-turbo.
+    
+    Rate Limits:
+        - 30 requests per minute
+        - 14,400 requests per day
+        - 25 MB max file size
+    
+    Example:
+        transcriber = GroqTranscriber(
+            api_key="your-api-key",
+            model="whisper-large-v3"
+        )
+        text = await transcriber.transcribe(audio_bytes, language="it")
+    """
+    
+    def __init__(self, api_key: str, model: str = "whisper-large-v3", **kwargs):
+        """
+        Initialize Groq transcriber.
+        
+        Args:
+            api_key: Groq API key
+            model: Whisper model to use ("whisper-large-v3" or "whisper-large-v3-turbo")
+            **kwargs: Additional configuration (timeout, retries, etc.)
+        """
+        super().__init__(api_key=api_key, model=model, **kwargs)
+        
+        self.timeout = kwargs.get("timeout", 60)  # Default 60 seconds
+        self.retries = kwargs.get("retries", 3)  # Default 3 retries
+        self._client: Optional[httpx.AsyncClient] = None
+    
+    async def initialize(self) -> bool:
+        """
+        Initialize the HTTP client.
+        
+        Returns:
+            True if initialization successful
+        """
+        try:
+            if self._client is None:
+                timeout = httpx.Timeout(self.timeout)
+                self._client = httpx.AsyncClient(timeout=timeout)
+            
+            # Validate model
+            if self.model not in GROQ_WHISPER_MODELS:
+                logger.warning(
+                    f"Model '{self.model}' not in known models. "
+                    f"Available: {list(GROQ_WHISPER_MODELS.keys())}"
+                )
+            
+            self._initialized = True
+            logger.info(f"Groq transcriber initialized with model: {self.model}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize Groq transcriber: {e}")
+            return False
+    
+    async def close(self):
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+        self._initialized = False
+        logger.info("Groq transcriber closed")
+    
+    async def transcribe(self, audio_data: bytes, language: str = "it") -> str:
+        """
+        Transcribe audio data using Groq Whisper API.
+        
+        Args:
+            audio_data: Raw audio file bytes (max 25MB)
+            language: Language code (default: "it" for Italian)
+        
+        Returns:
+            Transcribed text as string
+        
+        Raises:
+            TranscriptionError: If transcription fails
+        """
+        if not self._initialized:
+            await self.initialize()
+        
+        # Validate audio size
+        max_size = GROQ_RATE_LIMITS["max_file_size_mb"] * 1024 * 1024
+        if len(audio_data) > max_size:
+            raise TranscriptionError(
+                f"Audio file too large: {len(audio_data) / (1024*1024):.2f}MB "
+                f"(max: {GROQ_RATE_LIMITS['max_file_size_mb']}MB)",
+                provider="groq"
+            )
+        
+        # Prepare the request
+        files = {
+            "file": ("audio.wav", audio_data, "audio/wav"),
+            "model": (None, self.model),
+            "language": (None, language),
+            "response_format": (None, "json"),
+        }
+        
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        
+        # Execute with retries
+        last_error = None
+        for attempt in range(self.retries):
+            try:
+                logger.debug(f"Transcription attempt {attempt + 1}/{self.retries}")
+                
+                response = await self._client.post(
+                    GROQ_WHISPER_URL,
+                    headers=headers,
+                    files=files
+                )
+                
+                if response.status_code == 200:
+                    result = response.json()
+                    text = result.get("text", "").strip()
+                    
+                    if not text:
+                        logger.warning("Transcription returned empty text")
+                        return "[Audio ricevuto ma nessun contenuto rilevato]"
+                    
+                    logger.info(f"Transcription successful ({len(text)} chars)")
+                    return text
+                
+                elif response.status_code == 429:
+                    # Rate limit exceeded
+                    retry_after = int(response.headers.get("Retry-After", 5))
+                    logger.warning(f"Rate limit exceeded, waiting {retry_after}s")
+                    await asyncio.sleep(retry_after)
+                    continue
+                
+                else:
+                    error_text = response.text[:200]
+                    logger.error(f"Groq API error: {response.status_code} - {error_text}")
+                    
+                    if response.status_code >= 500:
+                        # Server error, retry
+                        await asyncio.sleep(2 ** attempt)  # Exponential backoff
+                        continue
+                    else:
+                        # Client error, don't retry
+                        raise TranscriptionError(
+                            f"Groq API error: {response.status_code} - {error_text}",
+                            provider="groq"
+                        )
+            
+            except httpx.HTTPError as e:
+                last_error = e
+                logger.warning(f"Request failed (attempt {attempt + 1}): {e}")
+                await asyncio.sleep(2 ** attempt)  # Exponential backoff
+                continue
+        
+        # All retries failed
+        error_msg = f"Transcription failed after {self.retries} attempts"
+        if last_error:
+            error_msg += f": {last_error}"
+        
+        logger.error(error_msg)
+        raise TranscriptionError(error_msg, provider="groq")
+    
+    @property
+    def rate_limits(self) -> dict:
+        """Return current Groq rate limits."""
+        return GROQ_RATE_LIMITS.copy()
+    
+    @property
+    def model_info(self) -> Optional[dict]:
+        """Return information about the current model."""
+        return GROQ_WHISPER_MODELS.get(self.model)
+    
+    def __str__(self) -> str:
+        model_info = self.model_info
+        if model_info:
+            return f"Groq transcriber ({self.model}) - {model_info['description']}"
+        return f"Groq transcriber ({self.model})"

--- a/src/telegram_acp_bot/audio_transcriber/transcriber.py
+++ b/src/telegram_acp_bot/audio_transcriber/transcriber.py
@@ -1,0 +1,289 @@
+"""
+Audio Transcriber Main Module
+
+Main entry point for audio transcription functionality.
+Handles provider selection, initialization, and transcription requests.
+"""
+
+import asyncio
+import logging
+from typing import Optional, Type
+from .config import TranscriberConfig, get_config
+from .providers.base import BaseTranscriber, TranscriptionError
+from .providers.groq import GroqTranscriber
+
+logger = logging.getLogger(__name__)
+
+
+class AudioTranscriber:
+    """
+    Main audio transcriber class.
+    
+    Manages transcription providers and handles transcription requests.
+    Supports multiple providers with automatic fallback.
+    
+    Example:
+        transcriber = AudioTranscriber()
+        await transcriber.initialize()
+        
+        text = await transcriber.transcribe(audio_bytes)
+        
+        await transcriber.close()
+    """
+    
+    # Provider registry - add new providers here
+    PROVIDERS: dict[str, Type[BaseTranscriber]] = {
+        "groq": GroqTranscriber,
+        # Add more providers here:
+        # "openai": OpenAITranscriber,
+        # "azure": AzureTranscriber,
+    }
+    
+    def __init__(self, config: Optional[TranscriberConfig] = None):
+        """
+        Initialize the audio transcriber.
+        
+        Args:
+            config: Optional configuration instance. If None, uses global config.
+        """
+        self.config = config or get_config()
+        self._transcriber: Optional[BaseTranscriber] = None
+        self._fallback_transcriber: Optional[BaseTranscriber] = None
+        self._initialized = False
+    
+    async def initialize(self) -> bool:
+        """
+        Initialize the transcription service.
+        
+        Returns:
+            True if initialization successful, False otherwise
+        """
+        if self._initialized:
+            logger.debug("Transcriber already initialized")
+            return True
+        
+        if not self.config.enabled:
+            logger.info("Audio transcription is disabled")
+            return False
+        
+        try:
+            # Initialize primary transcriber
+            self._transcriber = await self._create_transcriber(
+                self.config.provider,
+                self._get_api_key(self.config.provider)
+            )
+            
+            if self._transcriber:
+                await self._transcriber.initialize()
+                logger.info(f"Primary transcriber initialized: {self.config.provider}")
+            
+            # Initialize fallback if enabled
+            if self.config.fallback_enabled and self.config.fallback_provider:
+                if self.config.fallback_provider != self.config.provider:
+                    self._fallback_transcriber = await self._create_transcriber(
+                        self.config.fallback_provider,
+                        self._get_api_key(self.config.fallback_provider)
+                    )
+                    if self._fallback_transcriber:
+                        await self._fallback_transcriber.initialize()
+                        logger.info(
+                            f"Fallback transcriber initialized: "
+                            f"{self.config.fallback_provider}"
+                        )
+            
+            self._initialized = True
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize transcriber: {e}")
+            return False
+    
+    async def _create_transcriber(
+        self, 
+        provider: str, 
+        api_key: Optional[str]
+    ) -> Optional[BaseTranscriber]:
+        """
+        Create a transcriber instance for the specified provider.
+        
+        Args:
+            provider: Provider name ("groq", "openai", etc.)
+            api_key: API key for the provider
+        
+        Returns:
+            Transcriber instance or None if not available
+        """
+        if provider not in self.PROVIDERS:
+            logger.error(f"Unknown provider: {provider}")
+            return None
+        
+        if not api_key:
+            logger.error(f"No API key for provider: {provider}")
+            return None
+        
+        transcriber_class = self.PROVIDERS[provider]
+        return transcriber_class(
+            api_key=api_key,
+            model=self.config.whisper_model,
+            timeout=self.config.timeout,
+            retries=self.config.retries,
+        )
+    
+    def _get_api_key(self, provider: str) -> Optional[str]:
+        """Get API key for the specified provider."""
+        if provider == "groq":
+            return self.config.groq_api_key
+        elif provider == "openai":
+            return self.config.openai_api_key
+        return None
+    
+    async def transcribe(
+        self, 
+        audio_data: bytes, 
+        language: Optional[str] = None
+    ) -> str:
+        """
+        Transcribe audio data to text.
+        
+        Args:
+            audio_data: Raw audio file bytes
+            language: Optional language code (uses config default if None)
+        
+        Returns:
+            Transcribed text
+        
+        Raises:
+            TranscriptionError: If transcription fails
+        """
+        if not self._initialized:
+            await self.initialize()
+        
+        if not self.config.enabled:
+            raise TranscriptionError(
+                "Audio transcription is disabled",
+                provider="config"
+            )
+        
+        if not self._transcriber:
+            raise TranscriptionError(
+                "No transcriber available",
+                provider=self.config.provider
+            )
+        
+        # Use provided language or default
+        lang = language or self.config.language
+        
+        # Try primary transcriber
+        try:
+            logger.debug(f"Transcribing audio with {self.config.provider}")
+            return await self._transcriber.transcribe(audio_data, lang)
+        
+        except TranscriptionError as e:
+            logger.warning(f"Primary transcription failed: {e}")
+            
+            # Try fallback if available
+            if self._fallback_transcriber:
+                try:
+                    logger.info("Trying fallback transcriber")
+                    return await self._fallback_transcriber.transcribe(audio_data, lang)
+                
+                except TranscriptionError as fallback_error:
+                    logger.error(f"Fallback transcription also failed: {fallback_error}")
+            
+            # Re-raise original error
+            raise
+    
+    async def close(self):
+        """Close all transcribers and cleanup resources."""
+        if self._transcriber:
+            await self._transcriber.close()
+            self._transcriber = None
+        
+        if self._fallback_transcriber:
+            await self._fallback_transcriber.close()
+            self._fallback_transcriber = None
+        
+        self._initialized = False
+        logger.info("Audio transcriber closed")
+    
+    @property
+    def is_available(self) -> bool:
+        """Check if transcription service is available."""
+        return self._initialized and self._transcriber is not None
+    
+    @property
+    def provider_name(self) -> str:
+        """Get the name of the current provider."""
+        return self.config.provider
+    
+    def get_status(self) -> dict:
+        """
+        Get current status of the transcription service.
+        
+        Returns:
+            Dictionary with status information
+        """
+        return {
+            "enabled": self.config.enabled,
+            "initialized": self._initialized,
+            "provider": self.config.provider,
+            "model": self.config.whisper_model,
+            "language": self.config.language,
+            "available": self.is_available,
+            "fallback_enabled": self.config.fallback_enabled,
+            "fallback_provider": self.config.fallback_provider,
+        }
+
+
+# Global transcriber instance (lazy loaded)
+_transcriber: Optional[AudioTranscriber] = None
+
+
+def get_transcriber() -> AudioTranscriber:
+    """
+    Get the global transcriber instance.
+    
+    Returns:
+        AudioTranscriber instance
+    """
+    global _transcriber
+    if _transcriber is None:
+        _transcriber = AudioTranscriber()
+    return _transcriber
+
+
+async def initialize_transcriber() -> bool:
+    """
+    Initialize the global transcriber.
+    
+    Returns:
+        True if initialization successful
+    """
+    transcriber = get_transcriber()
+    return await transcriber.initialize()
+
+
+async def transcribe_audio(
+    audio_data: bytes, 
+    language: Optional[str] = None
+) -> str:
+    """
+    Transcribe audio using the global transcriber.
+    
+    Args:
+        audio_data: Raw audio file bytes
+        language: Optional language code
+    
+    Returns:
+        Transcribed text
+    """
+    transcriber = get_transcriber()
+    return await transcriber.transcribe(audio_data, language)
+
+
+async def close_transcriber():
+    """Close the global transcriber."""
+    global _transcriber
+    if _transcriber:
+        await _transcriber.close()
+        _transcriber = None

--- a/src/telegram_acp_bot/audio_transcriber/voice_handler.py
+++ b/src/telegram_acp_bot/audio_transcriber/voice_handler.py
@@ -1,0 +1,86 @@
+"""
+Voice Message Handler for Telegram ACP Bot
+
+This module contains ALL the logic for handling voice messages.
+It's designed to be called from the patched bot.py with a SINGLE function call.
+
+Usage in bot.py (patch):
+    from audio_transcriber.voice_handler import handle_voice
+    text = await handle_voice(message, context, text)
+
+This way, the bot.py patch is MINIMAL and survives updates better.
+"""
+
+import logging
+from typing import Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_voice(
+    message: "Message",
+    context: ContextTypes.DEFAULT_TYPE,
+    text: str
+) -> str:
+    """
+    Handle voice message received from Telegram.
+    
+    This function:
+    1. Checks if the message contains a voice note
+    2. Downloads the audio file
+    3. Transcribes it using the audio_transcriber module
+    4. Combines with existing text
+    
+    Args:
+        message: Telegram message object
+        context: Telegram bot context
+        text: Original message text (may be empty)
+    
+    Returns:
+        Combined text (original + transcription if voice message)
+    """
+    # Check if message contains a voice note
+    if not (message.voice and message.voice.file_id):
+        return text
+    
+    try:
+        logger.info("Voice message detected, transcribing...")
+        
+        # Download the voice message
+        file = await context.bot.get_file(message.voice.file_id)
+        audio_data = await file.download_as_bytearray()
+        
+        # Transcribe using the main transcriber module
+        from audio_transcriber import transcribe_audio, TranscriptionError
+        
+        audio_text = await transcribe_audio(bytes(audio_data))
+        
+        # Handle result
+        if audio_text:
+            logger.info(f"Transcription successful ({len(audio_text)} chars)")
+            result = f"[Trascrizione audio]: {audio_text}"
+        else:
+            logger.warning("Transcription returned empty text")
+            result = "[Audio ricevuto ma nessun contenuto rilevato]"
+        
+        # Combine with existing text
+        if text and result:
+            return f"{text}\n\n{result}"
+        return result
+    
+    except TranscriptionError as e:
+        logger.error(f"Transcription failed: {e}")
+        error_msg = f"[Errore trascrizione audio: {e}]"
+        if text:
+            return f"{text}\n\n{error_msg}"
+        return error_msg
+    
+    except Exception as e:
+        logger.error(f"Voice message handling error: {e}")
+        error_msg = "[Errore nella gestione del messaggio vocale]"
+        if text:
+            return f"{text}\n\n{error_msg}"
+        return error_msg

--- a/src/telegram_acp_bot/telegram/bridge.py
+++ b/src/telegram_acp_bot/telegram/bridge.py
@@ -160,7 +160,7 @@ class TelegramBridge:
         app.add_handler(CallbackQueryHandler(self.on_scheduled_callback, pattern=r"^scheduled\|"))
         app.add_handler(CallbackQueryHandler(self.on_busy_callback, pattern=r"^busy\|"))
         app.add_handler(
-            MessageHandler((filters.TEXT | filters.PHOTO | filters.Document.ALL) & ~filters.COMMAND, self.on_message)
+            MessageHandler((filters.TEXT | filters.PHOTO | filters.Document.ALL | filters.VOICE) & ~filters.COMMAND, self.on_message)
         )
 
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -886,9 +886,38 @@ class TelegramBridge:
         message = update.message
         if message is None:
             return None
+        
+        # Handle voice messages - transcribe to text
         text = message.text or message.caption or ""
+        
+        # Check for voice message
+        if message.voice and message.voice.file_id:
+            logger.info("Voice message received, downloading and transcribing...")
+            try:
+                file = await context.bot.get_file(message.voice.file_id)
+                audio_data = await file.download_as_bytearray()
+                logger.info("Voice message downloaded: %d bytes", len(audio_data))
+                from telegram_acp_bot.audio_transcriber import transcribe_audio
+                audio_text = await transcribe_audio(bytes(audio_data))
+                logger.info("Transcription result: %s", audio_text[:100] if audio_text else "empty")
+                if audio_text:
+                    transcription = f"[Trascrizione audio]: {audio_text}"
+                    text = f"{text}\n\n{transcription}" if text else transcription
+                else:
+                    text = "[Audio ricevuto ma nessun contenuto rilevato]" if not text else text
+            except Exception as exc:
+                logger.exception("Voice message transcription failed: %s", exc)
+                text = f"{text}\n\n[Errore trascrizione: {exc}]" if text else f"[Errore trascrizione: {exc}]"
+        
         images = await self._extract_prompt_images(message=message, context=context)
         files = await self._extract_prompt_files(message=message, context=context)
+        
+        # For voice messages, always return even if no text (the audio was the message)
+        if message.voice and message.voice.file_id and not images and not files:
+            if not text:
+                text = "[Voice message ricevuto]"
+            return _PromptInput(chat_id=self._chat_id(update), text=text, images=images, files=files)
+        
         if not text and not images and not files:
             return None
         return _PromptInput(chat_id=self._chat_id(update), text=text, images=images, files=files)


### PR DESCRIPTION
## Summary

Add optional voice message transcription support for Telegram voice notes.

This PR introduces a new `audio_transcriber` module and routes Telegram `voice` messages through that module before sending the resulting text prompt to the ACP agent.

## What is included

- a new `src/telegram_acp_bot/audio_transcriber/` package
- a provider abstraction for speech-to-text backends
- a Groq example provider
- Telegram voice handling integrated into the inbound message flow
- environment-based configuration for enabling transcription and selecting a provider
- a small ACP compatibility import change (`KillTerminalCommandResponse` -> `KillTerminalResponse`)

## Current behavior

When the feature is enabled and a Telegram voice note is received:

1. the bot downloads the voice payload from Telegram
2. the audio is sent to the configured transcription provider
3. the transcribed text is appended to the user prompt
4. the ACP agent receives text, not an ACP audio block

## Scope note

This implementation follows the "transcribe to text" approach discussed in issue #38. It does **not** yet implement native ACP audio blocks or capability-gated audio input.

## Configuration

The implementation expects environment variables for the transcription feature and provider credentials.

## Related

- Related to #38

## Notes for review

- The implementation was developed with AI assistance.
- Feedback on architecture, ACP alignment, and feature scope is very welcome.
