### PR TITLE
Upgrade ty to 0.0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ test = [
 lint = ["ruff"]
 qa = [
     { include-group = "lint" },
-    "ty>=0.0.19",
+    "ty>=0.0.27",
     "playwright>=1.55.0",
 ]
 docs = [


### PR DESCRIPTION
## Summary
- bump `ty` from `0.0.19` to `0.0.27` in the `qa` dependency group
- refresh the local environment with `uv` so `ty check` uses the current release

## Validation
- `uv run ruff check`
- `uv run --group qa ty check`
- `uv run pytest`
