### PR TITLE
Fix querying activity rendering

### DIFF
--- a/src/telegram_acp_bot/telegram/bridge.py
+++ b/src/telegram_acp_bot/telegram/bridge.py
@@ -1507,6 +1507,8 @@ class TelegramBridge:
         title = block.title.strip()
         if block.kind == "think":
             return ""
+        if block.kind == "search":
+            return TelegramBridge._normalize_search_activity_part(title, workspace=workspace)
         if block.kind == "execute" and title.startswith("Run "):
             command = title[4:].strip()
             if command:
@@ -1520,10 +1522,51 @@ class TelegramBridge:
     @staticmethod
     def _normalize_activity_text(block: AgentActivityBlock, *, workspace: Path | None = None) -> str:
         text = block.text.strip()
+        if block.kind == "search":
+            return TelegramBridge._normalize_search_activity_part(text, workspace=workspace)
         path_prefix = TelegramBridge._path_prefix_for_kind(block.kind)
         if path_prefix and text.startswith(path_prefix) and "\n" not in text:
             return TelegramBridge._format_read_path(text[len(path_prefix) :], workspace=workspace)
         return text
+
+    @staticmethod
+    def _normalize_search_activity_part(text: str, *, workspace: Path | None = None) -> str:
+        stripped = text.strip()
+        if not stripped:
+            return ""
+        if stripped.startswith("List "):
+            paths = TelegramBridge._split_prefixed_items(stripped, prefix="List ")
+            if not paths:
+                return stripped
+            seen: set[str] = set()
+            rendered: list[str] = []
+            for path in paths:
+                normalized = TelegramBridge._format_search_path(path, workspace=workspace)
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                rendered.append(f"List {normalized}")
+            return ", ".join(rendered)
+        if stripped.startswith("Search "):
+            pattern = stripped[len("Search ") :].strip().replace("`", "\\`")
+            if pattern:
+                return f"Search `{pattern}`"
+        return stripped
+
+    @staticmethod
+    def _split_prefixed_items(text: str, *, prefix: str) -> list[str]:
+        if not text.startswith(prefix):
+            return []
+        remainder = text[len(prefix) :]
+        separator = f", {prefix}"
+        return [item.strip() for item in remainder.split(separator) if item.strip()]
+
+    @staticmethod
+    def _format_search_path(raw_path: str, *, workspace: Path | None) -> str:
+        raw = raw_path.strip()
+        if workspace is not None and raw == workspace.name:
+            return TelegramBridge._format_read_path(".", workspace=workspace)
+        return TelegramBridge._format_read_path(raw, workspace=workspace)
 
     @staticmethod
     def _escape_markdown_preserving_code(text: str, *, allow_basic_markdown: bool = False) -> str:

--- a/src/telegram_acp_bot/telegram/bridge.py
+++ b/src/telegram_acp_bot/telegram/bridge.py
@@ -1572,21 +1572,28 @@ class TelegramBridge:
     def _escape_markdown_preserving_code(text: str, *, allow_basic_markdown: bool = False) -> str:
         escaped: list[str] = []
         in_code = False
+        previous_char = ""
         for char in text:
             if char == "`":
-                in_code = not in_code
+                if previous_char != "\\":
+                    in_code = not in_code
                 escaped.append(char)
+                previous_char = char
                 continue
             if in_code:
                 escaped.append(char)
+                previous_char = char
                 continue
             if char in {"\\", "["}:
                 escaped.append(f"\\{char}")
+                previous_char = char
                 continue
             if not allow_basic_markdown and char in {"_", "*"}:
                 escaped.append(f"\\{char}")
+                previous_char = char
                 continue
             escaped.append(char)
+            previous_char = char
         return "".join(escaped)
 
     @staticmethod

--- a/tests/telegram/test_messages.py
+++ b/tests/telegram/test_messages.py
@@ -638,6 +638,20 @@ async def test_format_activity_block_search_renders_patterns_as_inline_code():
     assert r"Search `AGENTS\.md|pedidos`" in rendered
 
 
+async def test_format_activity_block_search_keeps_escaped_backticks_inside_inline_code():
+    block = AgentActivityBlock(
+        kind="search",
+        title=r"Search foo`bar[baz]_qux",
+        status="completed",
+        text="",
+    )
+
+    rendered = TelegramBridge._format_activity_block(block)
+
+    assert r"Search `foo\`bar[baz]_qux`" in rendered
+    assert r"foo\`bar[baz]_qux" in rendered
+
+
 async def test_format_activity_block_search_list_uses_workspace_root_for_basename_match():
     workspace = Path("/home/tin/lab/custom")
     block = AgentActivityBlock(

--- a/tests/telegram/test_messages.py
+++ b/tests/telegram/test_messages.py
@@ -625,6 +625,70 @@ async def test_format_activity_block_search_uses_neutral_label_for_file_uri():
     assert "*🔎 Querying*" in rendered
 
 
+async def test_format_activity_block_search_renders_patterns_as_inline_code():
+    block = AgentActivityBlock(
+        kind="search",
+        title=r"Search AGENTS\.md|pedidos",
+        status="completed",
+        text="",
+    )
+
+    rendered = TelegramBridge._format_activity_block(block)
+
+    assert r"Search `AGENTS\.md|pedidos`" in rendered
+
+
+async def test_format_activity_block_search_list_uses_workspace_root_for_basename_match():
+    workspace = Path("/home/tin/lab/custom")
+    block = AgentActivityBlock(
+        kind="search",
+        title="List custom",
+        status="completed",
+        text="",
+    )
+
+    rendered = TelegramBridge._format_activity_block(block, workspace=workspace)
+
+    assert "List `/home/tin/lab/custom`" in rendered
+    assert "/home/tin/lab/custom/custom" not in rendered
+
+
+async def test_format_activity_block_search_list_collapses_duplicate_entries():
+    block = AgentActivityBlock(
+        kind="search",
+        title="List /home/tin/lab/custom/custom, List /home/tin/lab/custom/custom",
+        status="completed",
+        text="",
+    )
+
+    rendered = TelegramBridge._format_activity_block(block)
+
+    assert rendered.count("List `/home/tin/lab/custom/custom`") == 1
+
+
+async def test_format_activity_block_search_keeps_incomplete_list_marker_as_plain_text():
+    block = AgentActivityBlock(
+        kind="search",
+        title="List ",
+        status="completed",
+        text="",
+    )
+
+    rendered = TelegramBridge._format_activity_block(block)
+
+    assert "List" in rendered
+
+
+async def test_split_prefixed_items_returns_empty_when_prefix_is_missing():
+    assert TelegramBridge._split_prefixed_items("Query project", prefix="List ") == []
+
+
+async def test_normalize_search_activity_part_keeps_plain_text_when_list_items_are_missing(monkeypatch):
+    monkeypatch.setattr(TelegramBridge, "_split_prefixed_items", staticmethod(lambda text, prefix: []))
+
+    assert TelegramBridge._normalize_search_activity_part("List something") == "List something"
+
+
 async def test_format_activity_block_reply_and_fallback_helpers():
     block = AgentActivityBlock(kind="reply", title="ignored", status="completed", text="final")
 


### PR DESCRIPTION
## Summary
- render `Search ...` activity patterns as inline code in Telegram querying blocks
- normalize `List ...` search entries relative to the workspace root instead of duplicating basename paths
- collapse duplicate list entries in the same querying activity block

## Validation
- `uv run ruff check src/telegram_acp_bot/telegram/bridge.py tests/telegram/test_messages.py`
- `uv run ty check src/telegram_acp_bot/telegram/bridge.py tests/telegram/test_messages.py`
- `uv run pytest`
