### PR TITLE
feat: automatic config file discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,20 @@ You can mix layers freely. A typical setup uses a config file for static values 
 
 ## Config file
 
-Pass `--config <path>` (or set it in a wrapper script) to load settings from a JSON file.
+The bot automatically loads configuration from the following locations (in order):
+
+1. `./.telegram_acp_bot/config.json` (project-local)
+2. `~/.config/telegram_acp_bot/config.json` (XDG-compliant)
+3. `~/.telegram_acp_bot/config.json` (legacy)
+
+The first existing file is used. You can also specify an explicit path with `--config`.
 
 ```bash
-telegram-acp-bot --config ./telegram-acp.json
+# Automatic discovery (no --config needed if file exists)
+telegram-acp-bot
+
+# Explicit path (overrides automatic discovery)
+telegram-acp-bot --config ./telegram-acp-bot.json
 ```
 
 The file must be a JSON object. All keys are optional. Missing keys fall back to environment variables or built-in defaults.
@@ -29,7 +39,7 @@ The file must be a JSON object. All keys are optional. Missing keys fall back to
   },
   "acp": {
     "agent_command": "npx @zed-industries/codex-acp",
-    "restart_command": "uv run telegram-acp-bot --config ./telegram-acp.json",
+    "restart_command": "uv run telegram-acp-bot --config ./telegram-acp-bot.json",
     "permission_mode": "ask",
     "permission_event_output": "stdout",
     "stdio_limit": 8388608,
@@ -175,7 +185,7 @@ The equivalent config file is:
 Then run:
 
 ```bash
-telegram-acp-bot --config ./telegram-acp.json
+telegram-acp-bot --config ./telegram-acp-bot.json
 ```
 
 ### Mixed setup (env override for secrets)
@@ -194,7 +204,7 @@ Keep the token in the environment and everything else in the config file:
 ```
 
 ```bash
-TELEGRAM_BOT_TOKEN=123456:abc telegram-acp-bot --config ./telegram-acp.json
+TELEGRAM_BOT_TOKEN=123456:abc telegram-acp-bot --config ./telegram-acp-bot.json
 ```
 
 The environment variable wins over the config file for `bot_token`, so you can rotate the token without touching the file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,10 +13,10 @@ You can mix layers freely. A typical setup uses a config file for static values 
 The bot automatically loads configuration from the following locations (in order):
 
 1. `./.telegram_acp_bot/config.json` (project-local)
-2. `~/.config/telegram_acp_bot/config.json` (default config-directory path)
+2. `{envvar}`XDG_CONFIG_HOME`/telegram_acp_bot/config.json` (or `~/.config/telegram_acp_bot/config.json` when unset)
 3. `~/.telegram_acp_bot/config.json` (legacy)
 
-The first existing file is used. You can also specify an explicit path with `--config`.
+The first readable file is used. You can also specify an explicit path with `--config`.
 
 ```bash
 # Automatic discovery (no --config needed if file exists)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ You can mix layers freely. A typical setup uses a config file for static values 
 The bot automatically loads configuration from the following locations (in order):
 
 1. `./.telegram_acp_bot/config.json` (project-local)
-2. `~/.config/telegram_acp_bot/config.json` (XDG-compliant)
+2. `~/.config/telegram_acp_bot/config.json` (default config-directory path)
 3. `~/.telegram_acp_bot/config.json` (legacy)
 
 The first existing file is used. You can also specify an explicit path with `--config`.

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -310,7 +310,7 @@ def _run_bot_loop(
 def _find_config_file() -> Path | None:
     """Find a config file from standard locations.
 
-    Returns the first existing config file from:
+    Returns the first readable config file from:
     1. ./.telegram_acp_bot/config.json
     2. $XDG_CONFIG_HOME/telegram_acp_bot/config.json
        (or ~/.config/telegram_acp_bot/config.json when XDG_CONFIG_HOME is unset)
@@ -326,9 +326,32 @@ def _find_config_file() -> Path | None:
     ]
 
     for path in candidates:
-        if path.exists():
+        if path.is_file():
             return path
     return None
+
+
+def _load_preparsed_config(
+    parser: argparse.ArgumentParser,
+    config_arg: str | None,
+) -> dict[str, Any]:
+    """Load config-file defaults selected during pre-parsing."""
+    if config_arg is not None:
+        if not config_arg.strip():
+            parser.error("--config must not be empty or whitespace")
+        config_path = Path(config_arg).expanduser()
+    else:
+        config_path = _find_config_file()
+
+    if config_path is None:
+        return {}
+
+    try:
+        config_data = load_config_file(config_path)
+    except ConfigFileError as exc:
+        parser.error(str(exc))
+    _apply_config_file_defaults(parser, config_data)
+    return config_data
 
 
 def main(args: list[str] | None = None) -> int:
@@ -346,20 +369,7 @@ def main(args: list[str] | None = None) -> int:
     # Pre-parse to extract --config before full argument resolution
     pre_opts, _ = parser.parse_known_args(args=argv)
 
-    config_data: dict[str, Any] = {}
-    if pre_opts.config is not None:
-        if not pre_opts.config.strip():
-            parser.error("--config must not be empty or whitespace")
-        config_path = Path(pre_opts.config).expanduser()
-    else:
-        config_path = _find_config_file()
-
-    if config_path is not None:
-        try:
-            config_data = load_config_file(config_path)
-        except ConfigFileError as exc:
-            parser.error(str(exc))
-        _apply_config_file_defaults(parser, config_data)
+    config_data = _load_preparsed_config(parser, pre_opts.config)
 
     # Full parse: catches unknown/invalid flags for both the main command and subcommands.
     opts = parser.parse_args(args=argv)

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -312,14 +312,16 @@ def _find_config_file() -> Path | None:
 
     Returns the first existing config file from:
     1. ./.telegram_acp_bot/config.json
-    2. ~/.config/telegram_acp_bot/config.json
+    2. $XDG_CONFIG_HOME/telegram_acp_bot/config.json
+       (or ~/.config/telegram_acp_bot/config.json when XDG_CONFIG_HOME is unset)
     3. ~/.telegram_acp_bot/config.json
 
     Returns None if no config file is found.
     """
+    xdg_config_home = Path(os.environ.get("XDG_CONFIG_HOME") or "~/.config").expanduser()
     candidates = [
         Path(".telegram_acp_bot/config.json"),
-        Path("~/.config/telegram_acp_bot/config.json").expanduser(),
+        xdg_config_home / "telegram_acp_bot" / "config.json",
         Path("~/.telegram_acp_bot/config.json").expanduser(),
     ]
 

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -58,8 +58,9 @@ def get_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="PATH",
         help=(
-            "Path to a JSON config file. Values are overridden by environment variables"
-            " and CLI flags. See docs for the full schema."
+            "Path to a JSON config file. If not provided, the bot will automatically "
+            "look for config files in standard locations. Values are overridden by "
+            "environment variables and CLI flags. See docs for the full schema."
         ),
     )
     parser.add_argument("--telegram-token", default=os.getenv("TELEGRAM_BOT_TOKEN", ""), help="Telegram bot token")
@@ -306,6 +307,28 @@ def _run_bot_loop(
             return 1
 
 
+def _find_config_file() -> Path | None:
+    """Find a config file from standard locations.
+
+    Returns the first existing config file from:
+    1. ./.telegram_acp_bot/config.json
+    2. ~/.config/telegram_acp_bot/config.json
+    3. ~/.telegram_acp_bot/config.json
+
+    Returns None if no config file is found.
+    """
+    candidates = [
+        Path(".telegram_acp_bot/config.json"),
+        Path("~/.config/telegram_acp_bot/config.json").expanduser(),
+        Path("~/.telegram_acp_bot/config.json").expanduser(),
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
 def main(args: list[str] | None = None) -> int:
     """Run the main program.
 
@@ -322,8 +345,9 @@ def main(args: list[str] | None = None) -> int:
     pre_opts, _ = parser.parse_known_args(args=argv)
 
     config_data: dict[str, Any] = {}
-    if pre_opts.config:
-        config_path = Path(pre_opts.config).expanduser()
+    config_path = Path(pre_opts.config).expanduser() if pre_opts.config else _find_config_file()
+
+    if config_path:
         try:
             config_data = load_config_file(config_path)
         except ConfigFileError as exc:

--- a/src/telegram_acp_bot/__init__.py
+++ b/src/telegram_acp_bot/__init__.py
@@ -347,9 +347,14 @@ def main(args: list[str] | None = None) -> int:
     pre_opts, _ = parser.parse_known_args(args=argv)
 
     config_data: dict[str, Any] = {}
-    config_path = Path(pre_opts.config).expanduser() if pre_opts.config else _find_config_file()
+    if pre_opts.config is not None:
+        if not pre_opts.config.strip():
+            parser.error("--config must not be empty or whitespace")
+        config_path = Path(pre_opts.config).expanduser()
+    else:
+        config_path = _find_config_file()
 
-    if config_path:
+    if config_path is not None:
         try:
             config_data = load_config_file(config_path)
         except ConfigFileError as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 """Configuration for the pytest test suite."""
 
+from pathlib import Path
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def isolate_home_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def isolate_home_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Redirect HOME and XDG_CONFIG_HOME to a temporary directory.
 
     Prevents `_find_config_file()` from accidentally discovering real config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,17 @@
 """Configuration for the pytest test suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_home_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Redirect HOME and XDG_CONFIG_HOME to a temporary directory.
+
+    Prevents `_find_config_file()` from accidentally discovering real config
+    files in the developer's home directory, keeping tests hermetic.
+    The CWD-relative candidate (`.telegram_acp_bot/config.json`) is unaffected,
+    so tests that exercise auto-discovery can still do so by creating the file
+    under their own `tmp_path` and changing into it.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,5 +15,9 @@ def isolate_home_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     so tests that exercise auto-discovery can still do so by creating the file
     under their own `tmp_path` and changing into it.
     """
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    home_dir = tmp_path / "home"
+    xdg_config_home = tmp_path / "xdg-config"
+    home_dir.mkdir()
+    xdg_config_home.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import runpy
 import sys
 from importlib import metadata
@@ -544,3 +545,55 @@ def test_register_commands_subcommand_uses_config_file(mocker, monkeypatch, tmp_
     assert mock_register.call_count == 1
     assert mock_register.call_args is not None
     assert mock_register.call_args.args[0].telegram_token == "CFG_TOKEN"
+
+
+def test_main_auto_discovers_config_file(mocker, monkeypatch, tmp_path):
+    """Config file is automatically discovered from standard locations."""
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ACP_AGENT_COMMAND", raising=False)
+    mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
+
+    # Create config in one of the standard locations
+    config_dir = tmp_path / ".telegram_acp_bot"
+    config_dir.mkdir()
+    config_path = config_dir / "config.json"
+    config_path.write_text('{"telegram": {"bot_token": "AUTO_TOKEN"}, "acp": {"agent_command": "auto_agent"}}')
+
+    # Change to the temp directory and run without --config
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert main([]) == 0
+        config = mock_run_polling.call_args.args[0]
+        assert config.token == "AUTO_TOKEN"
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_main_explicit_config_overrides_auto_discovery(mocker, monkeypatch, tmp_path):
+    """Explicit --config path takes precedence over auto-discovered files."""
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ACP_AGENT_COMMAND", raising=False)
+    mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
+
+    # Create config in standard location
+    config_dir = tmp_path / ".telegram_acp_bot"
+    config_dir.mkdir()
+    auto_config = config_dir / "config.json"
+    auto_config.write_text('{"telegram": {"bot_token": "AUTO_TOKEN"}, "acp": {"agent_command": "auto_agent"}}')
+
+    # Create explicit config with different values
+    explicit_config = tmp_path / "explicit.json"
+    explicit_config.write_text(
+        '{"telegram": {"bot_token": "EXPLICIT_TOKEN"}, "acp": {"agent_command": "explicit_agent"}}'
+    )
+
+    # Change to the temp directory and run with explicit --config
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert main(["--config", str(explicit_config)]) == 0
+        config = mock_run_polling.call_args.args[0]
+        assert config.token == "EXPLICIT_TOKEN"
+    finally:
+        os.chdir(original_cwd)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import runpy
 import sys
 from importlib import metadata
@@ -559,15 +558,11 @@ def test_main_auto_discovers_config_file(mocker, monkeypatch, tmp_path):
     config_path = config_dir / "config.json"
     config_path.write_text('{"telegram": {"bot_token": "AUTO_TOKEN"}, "acp": {"agent_command": "auto_agent"}}')
 
-    # Change to the temp directory and run without --config
-    original_cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        assert main([]) == 0
-        config = mock_run_polling.call_args.args[0]
-        assert config.token == "AUTO_TOKEN"
-    finally:
-        os.chdir(original_cwd)
+    monkeypatch.chdir(tmp_path)
+
+    assert main([]) == 0
+    config = mock_run_polling.call_args.args[0]
+    assert config.token == "AUTO_TOKEN"
 
 
 def test_main_explicit_config_overrides_auto_discovery(mocker, monkeypatch, tmp_path):
@@ -588,12 +583,30 @@ def test_main_explicit_config_overrides_auto_discovery(mocker, monkeypatch, tmp_
         '{"telegram": {"bot_token": "EXPLICIT_TOKEN"}, "acp": {"agent_command": "explicit_agent"}}'
     )
 
-    # Change to the temp directory and run with explicit --config
-    original_cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        assert main(["--config", str(explicit_config)]) == 0
-        config = mock_run_polling.call_args.args[0]
-        assert config.token == "EXPLICIT_TOKEN"
-    finally:
-        os.chdir(original_cwd)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["--config", str(explicit_config)]) == 0
+    config = mock_run_polling.call_args.args[0]
+    assert config.token == "EXPLICIT_TOKEN"
+
+
+def test_main_auto_discovers_config_from_xdg_config_home(mocker, monkeypatch, tmp_path):
+    """Automatic discovery respects XDG_CONFIG_HOME before the legacy home path."""
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ACP_AGENT_COMMAND", raising=False)
+    mock_run_polling = mocker.patch("telegram_acp_bot.run_polling", return_value=0)
+    config_dir = tmp_path / "xdg" / "telegram_acp_bot"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.json"
+    config_path.write_text('{"telegram": {"bot_token": "XDG_TOKEN"}, "acp": {"agent_command": "xdg_agent"}}')
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    assert main([]) == 0
+    config = mock_run_polling.call_args.args[0]
+    assert config.token == "XDG_TOKEN"
+
+
+def test_main_rejects_blank_explicit_config_path():
+    """Blank explicit --config values fail instead of falling back to discovery."""
+    with pytest.raises(SystemExit, match="2"):
+        main(["--config", "   "])


### PR DESCRIPTION
Implement automatic config file discovery from standard locations:

- `.telegram_acp_bot/config.json` (project-local)
- `~/.config/telegram_acp_bot/config.json` (XDG-compliant)
- `~/.telegram_acp_bot/config.json` (legacy)

The first existing file is used automatically. Explicit `--config` path still takes precedence over automatic discovery.

Also update documentation to use `telegram-acp-bot.json` in examples instead of `telegram-acp.json` for consistency.

## Changes

- Added `_find_config_file()` function that searches standard locations
- Modified `main()` to use automatic discovery when `--config` is not provided
- Updated documentation with auto-discovery information and corrected examples
- Added comprehensive tests for auto-discovery behavior
- Updated help text for `--config` argument

## Testing

- All existing tests pass
- Added `test_main_auto_discovers_config_file`
- Added `test_main_explicit_config_overrides_auto_discovery`
- Manual testing confirms auto-discovery works as expected

## Backward Compatibility

✔ Fully backward compatible - existing `--config` usage continues to work exactly as before.