### PR TITLE
Fix Telegram markdown local file links

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -110,6 +110,12 @@ The available modes are:
 - `compact`: one in-progress status message that becomes the final answer.
 - `verbose`: in-place append-only streaming for reply text and active tool output.
 
+### Markdown replies
+
+Agent replies are rendered with Telegram entities where possible. Web links remain tappable, while local file links emitted
+by coding agents, such as `[activity.py](/home/user/project/activity.py:109)`, are shown as readable text because Telegram
+rejects local-path URLs. Inline code, emphasis, headings, and lists still render using Telegram formatting.
+
 (how-to-busy-queue)=
 ## 7. Busy-state handling
 

--- a/src/telegram_acp_bot/telegram/bridge.py
+++ b/src/telegram_acp_bot/telegram/bridge.py
@@ -107,6 +107,7 @@ SCHEDULED_PROMPT_TRY_LOCK_TIMEOUT_SECONDS = 1e-9
 SCHEDULED_MISSING_ANCHOR_ERROR = "scheduled task is missing an anchor message"
 SCHEDULED_TASK_PREVIEW_MAX_CHARS = 72
 SCHEDULE_COMMAND_MIN_ARGS = 2
+TELEGRAM_TEXT_LINK_SCHEMES = frozenset({"http", "https", "tg"})
 _SCHEDULE_DELAY_RE = re.compile(r"^(\d+)(s|m|h|d)$", re.IGNORECASE)
 
 
@@ -1606,6 +1607,26 @@ class TelegramBridge:
         )
 
     @staticmethod
+    def _is_safe_text_link_url(url: str | None) -> bool:
+        if not url:
+            return False
+        parsed = urlparse(url)
+        if parsed.scheme not in TELEGRAM_TEXT_LINK_SCHEMES:
+            return False
+        if parsed.scheme in {"http", "https"}:
+            return bool(parsed.netloc)
+        return bool(parsed.netloc or parsed.path)
+
+    @staticmethod
+    def _to_safe_telegram_entities(entities: list[MarkdownMessageEntity]) -> list[MessageEntity]:
+        rendered_entities: list[MessageEntity] = []
+        for entity in entities:
+            if entity.type == MessageEntity.TEXT_LINK and not TelegramBridge._is_safe_text_link_url(entity.url):
+                continue
+            rendered_entities.append(TelegramBridge._to_telegram_entity(entity))
+        return rendered_entities
+
+    @staticmethod
     async def _reply_activity_block(
         update: Update, block: AgentActivityBlock, *, workspace: Path | None = None
     ) -> None:
@@ -1851,9 +1872,11 @@ class TelegramBridge:
         rendered_chunks: list[tuple[str, list[MessageEntity] | None]] = []
         for chunk_text, chunk_entities in chunks:
             if chunk_entities:
-                rendered_chunks.append(
-                    (chunk_text, [TelegramBridge._to_telegram_entity(entity) for entity in chunk_entities])
-                )
+                telegram_entities = TelegramBridge._to_safe_telegram_entities(chunk_entities)
+                if telegram_entities:
+                    rendered_chunks.append((chunk_text, telegram_entities))
+                    continue
+                rendered_chunks.append((chunk_text, None))
                 continue
             rendered_chunks.append((chunk_text, None))
         return rendered_chunks

--- a/tests/telegram/test_messages.py
+++ b/tests/telegram/test_messages.py
@@ -1863,6 +1863,48 @@ async def test_reply_agent_uses_entities_split_flow(monkeypatch: pytest.MonkeyPa
     assert update.message.reply_kwargs[1] == {}
 
 
+async def test_render_markdown_chunks_drops_local_file_link_entity_but_keeps_other_formatting():
+    text = "## Findings\n- [activity.py](/home/user/project/activity.py:109): `foo_bar` **bad**\n"
+
+    chunks = TelegramBridge._render_markdown_chunks(text)
+
+    assert len(chunks) == 1
+    rendered_text, entities = chunks[0]
+    assert "[activity.py]" not in rendered_text
+    assert "](/home/user/project/activity.py:109)" not in rendered_text
+    assert "`" not in rendered_text
+    assert "activity.py" in rendered_text
+    assert "foo_bar" in rendered_text
+    assert entities is not None
+    entity_types = {entity.type for entity in entities}
+    assert MessageEntity.TEXT_LINK not in entity_types
+    assert MessageEntity.CODE in entity_types
+    assert MessageEntity.BOLD in entity_types
+
+
+async def test_render_markdown_chunks_keeps_web_text_link_entity():
+    chunks = TelegramBridge._render_markdown_chunks("[docs](https://example.com/docs)")
+
+    _, entities = chunks[0]
+    assert entities is not None
+    assert any(
+        entity.type == MessageEntity.TEXT_LINK and entity.url == "https://example.com/docs" for entity in entities
+    )
+
+
+async def test_render_markdown_chunks_drops_unsafe_link_entity_when_it_is_the_only_entity():
+    chunks = TelegramBridge._render_markdown_chunks("[file](/tmp/file.py)")
+
+    rendered_text, entities = chunks[0]
+    assert rendered_text == "file"
+    assert entities is None
+
+
+async def test_is_safe_text_link_url_allows_telegram_deep_links_and_rejects_empty_urls():
+    assert TelegramBridge._is_safe_text_link_url("tg://resolve?domain=telegram") is True
+    assert TelegramBridge._is_safe_text_link_url(None) is False
+
+
 async def test_reply_agent_falls_back_to_plain_text_on_convert_error(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- sanitize Markdown `text_link` entities before sending Telegram messages
- keep web and Telegram deep links clickable while rendering local file links as safe plain labels
- document Markdown reply behavior for local coding-agent links

Closes #206

## Tests
- `uv run pytest tests/telegram/test_messages.py -k "markdown_chunks or is_safe_text_link_url or reply_agent_uses_entities_split_flow or send_markdown_to_chat" --no-cov`
- `uv run ruff check`
- `make test`
- `make docs`
- `uv run ty check src/telegram_acp_bot/telegram/bridge.py`

## Notes
Full `uv run ty check` still reports existing unrelated diagnostics outside this change.
